### PR TITLE
security: require an access token before serving anything

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
 # FOUNDER OS — copy to .env.local and fill in. .env.local is gitignored.
 
+# ── Access control ───────────────────────────────────────────────────────
+# Shared token guarding the whole app. Leave blank for a local-only run; a
+# production server refuses to start serving without it, because this app holds
+# live payment and inbox credentials. Generate one with: openssl rand -hex 32
+FOUNDER_OS_ACCESS_TOKEN=
+
 # ── Email (up to 4 IMAP inboxes) ─────────────────────────────────────────
 # Gmail: use an App Password (Google Account → Security → 2FA → App passwords)
 INBOX_1_HOST=imap.gmail.com

--- a/README.md
+++ b/README.md
@@ -203,14 +203,48 @@ so they never touch the seeded dev DB.
 
 ---
 
+## Access control
+
+Founder OS is a **single-operator** system. There are no user accounts and the
+data model has no tenancy, so access control is one shared token in front of
+everything rather than per-user auth.
+
+- **Locally, nothing changes.** With `FOUNDER_OS_ACCESS_TOKEN` unset, a dev
+  server behaves exactly as before, and `npm run dev` binds to `127.0.0.1` so it
+  is not reachable from the rest of the network.
+- **Deployed, a token is required.** A production server with no token set
+  refuses to serve and explains why. This app can read your inboxes, send mail
+  as you, and store a Stripe key, so a missing secret fails loudly rather than
+  serving all of that to anyone with the URL.
+
+Set it, then open the app and enter the same value once:
+
+```bash
+openssl rand -hex 32     # put the result in FOUNDER_OS_ACCESS_TOKEN
+```
+
+Scripts and agents can present it as a header instead:
+
+```bash
+curl -H "Authorization: Bearer $FOUNDER_OS_ACCESS_TOKEN" https://your-app/api/connections
+```
+
+Inbound webhooks (`/api/webhooks/…`) stay reachable without it, since third
+parties cannot present your token. They carry their own secrets, so set
+`MANYCHAT_WEBHOOK_SECRET` if you use the ManyChat ingest.
+
+---
+
 ## Deploying to Railway
 
 1. Create a Railway project and point it at this repo.
 2. Set the build command to `npm run build` and the start command to `npm start`
    (the app serves on the `PORT` Railway provides).
-3. Add a database service and any connector credentials as environment variables
+3. **Set `FOUNDER_OS_ACCESS_TOKEN`** to a fresh random value (see **Access
+   control** above). The app will not serve without it.
+4. Add a database service and any connector credentials as environment variables
    in the Railway dashboard.
-4. Deploy. The knowledge services (G-Brain and Optimal Engine) run as companion
+5. Deploy. The knowledge services (G-Brain and Optimal Engine) run as companion
    services and are referenced by URL from the app's environment.
 
 ---

--- a/app/api/unlock/route.ts
+++ b/app/api/unlock/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { ACCESS_TOKEN_ENV, safeEqual, SESSION_COOKIE } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+const UnlockSchema = z.object({
+  token: z.string().min(1).max(512),
+  next: z.string().optional(),
+});
+
+/** Only same-site paths, so `next` cannot be turned into an open redirect. */
+function safeNext(next: string | undefined): string {
+  return next && next.startsWith('/') && !next.startsWith('//') ? next : '/';
+}
+
+function setSession(response: NextResponse, token: string): NextResponse {
+  response.cookies.set(SESSION_COOKIE, token, {
+    httpOnly: true, // page scripts can never read it
+    sameSite: 'lax', // another origin cannot ride it
+    secure: process.env.NODE_ENV === 'production', // plain-http localhost still works
+    path: '/',
+    maxAge: 60 * 60 * 24 * 30,
+  });
+  return response;
+}
+
+/**
+ * Exchange the access token for a session cookie.
+ *
+ * Accepts a JSON body (scripts) or a form post (the /unlock page), and answers
+ * in kind: JSON callers get JSON, browsers get a redirect.
+ */
+export async function POST(request: Request) {
+  const isForm = (request.headers.get('content-type') ?? '').includes('form');
+
+  const raw = isForm
+    ? Object.fromEntries(await request.formData().catch(() => new FormData()))
+    : await request.json().catch(() => null);
+
+  const parsed = UnlockSchema.safeParse(raw);
+  const configured = process.env[ACCESS_TOKEN_ENV]?.trim() ?? '';
+
+  if (configured.length === 0) {
+    const detail = `${ACCESS_TOKEN_ENV} is not set on this server`;
+    return isForm
+      ? new NextResponse(detail, {
+          status: 503,
+          headers: { 'content-type': 'text/plain' },
+        })
+      : NextResponse.json({ error: detail }, { status: 503 });
+  }
+
+  if (!parsed.success) {
+    return isForm
+      ? NextResponse.redirect(new URL('/unlock?error=1', request.url), 303)
+      : NextResponse.json({ error: 'expected { token }' }, { status: 400 });
+  }
+
+  const { token, next } = parsed.data;
+
+  if (!safeEqual(token, configured)) {
+    if (!isForm) return NextResponse.json({ error: 'incorrect token' }, { status: 401 });
+    const back = new URL('/unlock', request.url);
+    back.searchParams.set('error', '1');
+    if (next) back.searchParams.set('next', safeNext(next));
+    return NextResponse.redirect(back, 303);
+  }
+
+  // 303 so the browser follows with GET rather than re-posting the token.
+  return setSession(
+    isForm
+      ? NextResponse.redirect(new URL(safeNext(next), request.url), 303)
+      : NextResponse.json({ ok: true }),
+    configured,
+  );
+}
+
+/** Sign out: drop the session cookie. */
+export async function DELETE() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(SESSION_COOKIE, '', {
+    httpOnly: true,
+    path: '/',
+    maxAge: 0,
+  });
+  return response;
+}

--- a/app/unlock/page.tsx
+++ b/app/unlock/page.tsx
@@ -1,0 +1,60 @@
+import { ACCESS_TOKEN_ENV } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Token exchange. Deliberately a server component posting a plain form: it
+ * needs no client JavaScript, and it stays directly invocable so the smoke
+ * suite in tests/smoke.test.ts can render it like every other page.
+ */
+export default function UnlockPage({ searchParams }: { searchParams?: { next?: string; error?: string } }) {
+  // Only same-site paths survive, so `?next=` cannot be used as an open redirect.
+  const next = searchParams?.next;
+  const safeNext = next && next.startsWith('/') && !next.startsWith('//') ? next : '/';
+  const failed = searchParams?.error === '1';
+
+  return (
+    <main className="flex min-h-screen items-center justify-center p-6">
+      <form method="POST" action="/api/unlock" className="w-full max-w-sm">
+        <input type="hidden" name="next" value={safeNext} />
+
+        <p className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-[var(--text-3)]">// locked</p>
+        <h1 className="mt-1 font-mono text-2xl tracking-[0.08em] text-[var(--text-1)]">FOUNDER OS</h1>
+        <p className="mt-3 font-mono text-xs leading-relaxed text-[var(--text-3)]">
+          This instance holds live credentials. Enter its access token to continue.
+        </p>
+
+        <label htmlFor="token" className="sr-only">
+          Access token
+        </label>
+        <input
+          id="token"
+          name="token"
+          type="password"
+          required
+          autoFocus
+          autoComplete="current-password"
+          placeholder="access token"
+          className="mt-4 w-full border border-[var(--line)] bg-[var(--surface-2)] px-3 py-2 font-mono text-sm text-[var(--text-1)] outline-none focus:border-[var(--text-3)]"
+        />
+
+        {failed && (
+          <p role="alert" className="mt-2 font-mono text-xs text-[var(--danger,#f87171)]">
+            incorrect token
+          </p>
+        )}
+
+        <button
+          type="submit"
+          className="mt-3 w-full border border-[var(--line)] px-3 py-2 font-mono text-xs uppercase tracking-[0.16em] text-[var(--text-2)]"
+        >
+          unlock
+        </button>
+
+        <p className="mt-6 font-mono text-[11px] leading-relaxed text-[var(--text-3)]">
+          The operator sets this as <code>{ACCESS_TOKEN_ENV}</code> in the server environment.
+        </p>
+      </form>
+    </main>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,96 @@
+/**
+ * Access control for the whole surface.
+ *
+ * Founder OS is a single-operator system: there are no user accounts, and the
+ * data model has no tenancy. So authentication here is not "who are you" but
+ * "is this instance yours" — one shared token, checked once, in front of
+ * everything. Putting it in middleware rather than in each route means a new
+ * route is protected the moment it exists, instead of the moment someone
+ * remembers to guard it.
+ *
+ * The local demo stays zero-config: with no token set, a development server
+ * serves normally. A production server with no token set refuses to serve at
+ * all rather than quietly exposing Stripe keys and inbox passwords — a missing
+ * secret should fail loudly, not fail open.
+ */
+
+export const SESSION_COOKIE = 'founder_os_session';
+export const ACCESS_TOKEN_ENV = 'FOUNDER_OS_ACCESS_TOKEN';
+
+export type AuthDecision =
+  { kind: 'allow' } | { kind: 'unauthorized' } | { kind: 'misconfigured'; detail: string };
+
+export type AuthInput = {
+  /** Value of FOUNDER_OS_ACCESS_TOKEN, if any. */
+  token: string | undefined;
+  /** Presented credential: session cookie or `Authorization: Bearer …`. */
+  presented: string | undefined;
+  /** True when running a production build (NODE_ENV === 'production'). */
+  isProduction: boolean;
+};
+
+/**
+ * Constant-time string comparison. `===` returns as soon as two bytes differ,
+ * which leaks the shared secret one character at a time to anyone willing to
+ * measure. Middleware runs on the edge runtime, so node:crypto's
+ * timingSafeEqual is unavailable and this is written by hand.
+ */
+export function safeEqual(a: string, b: string): boolean {
+  // Length is not secret (the operator chose it) but must not short-circuit the
+  // loop, so compare over a fixed span and fold the length difference in.
+  const len = Math.max(a.length, b.length);
+  let diff = a.length ^ b.length;
+  for (let i = 0; i < len; i++) {
+    diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+  }
+  return diff === 0;
+}
+
+/** Pull a bearer credential out of an Authorization header, if present. */
+export function bearerFrom(header: string | null | undefined): string | undefined {
+  if (!header) return undefined;
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  return match ? match[1] : undefined;
+}
+
+export function decideAccess({ token, presented, isProduction }: AuthInput): AuthDecision {
+  const configured = token?.trim() ?? '';
+
+  if (configured.length === 0) {
+    // No token configured. Fine on a laptop; never fine once deployed.
+    if (isProduction) {
+      return {
+        kind: 'misconfigured',
+        detail: `${ACCESS_TOKEN_ENV} is not set. A deployed Founder OS holds live payment and inbox credentials, so it refuses to serve without one. Generate a token (\`openssl rand -hex 32\`) and set it in your host's environment.`,
+      };
+    }
+    return { kind: 'allow' };
+  }
+
+  if (configured.length < 16) {
+    return {
+      kind: 'misconfigured',
+      detail: `${ACCESS_TOKEN_ENV} must be at least 16 characters. Generate one with \`openssl rand -hex 32\`.`,
+    };
+  }
+
+  if (presented && safeEqual(presented, configured)) return { kind: 'allow' };
+  return { kind: 'unauthorized' };
+}
+
+/**
+ * Paths served before the token check.
+ *
+ * - `/unlock` is where an operator exchanges the token for a session cookie, so
+ *   gating it would lock everyone out.
+ * - The ManyChat webhook is machine-to-machine: ManyChat cannot present the
+ *   operator's token, and that route already authenticates itself with
+ *   MANYCHAT_WEBHOOK_SECRET.
+ */
+const PUBLIC_PATHS = ['/unlock', '/api/unlock', '/api/webhooks'];
+
+export function isPublicPath(pathname: string): boolean {
+  // Exact match, or a full segment beneath it. A bare `startsWith` would also
+  // open `/unlocked-secrets`, which is the sort of gap a gate cannot afford.
+  return PUBLIC_PATHS.some((base) => pathname === base || pathname.startsWith(`${base}/`));
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { ACCESS_TOKEN_ENV, bearerFrom, decideAccess, isPublicPath, SESSION_COOKIE } from '@/lib/auth';
+
+/**
+ * One gate in front of every page and API route. See lib/auth.ts for why this
+ * lives here rather than in each handler.
+ */
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  if (isPublicPath(pathname)) return NextResponse.next();
+
+  const decision = decideAccess({
+    token: process.env[ACCESS_TOKEN_ENV],
+    presented: request.cookies.get(SESSION_COOKIE)?.value ?? bearerFrom(request.headers.get('authorization')),
+    isProduction: process.env.NODE_ENV === 'production',
+  });
+
+  if (decision.kind === 'allow') return NextResponse.next();
+
+  const wantsJson = pathname.startsWith('/api/');
+
+  if (decision.kind === 'misconfigured') {
+    // 503, not 500: the app is fine, the deployment is incomplete.
+    return wantsJson
+      ? NextResponse.json({ error: decision.detail }, { status: 503 })
+      : new NextResponse(decision.detail, {
+          status: 503,
+          headers: { 'content-type': 'text/plain' },
+        });
+  }
+
+  if (wantsJson) {
+    return NextResponse.json(
+      {
+        error: `unauthorized — present the ${ACCESS_TOKEN_ENV} as \`Authorization: Bearer …\``,
+      },
+      { status: 401 },
+    );
+  }
+
+  const unlock = new URL('/unlock', request.url);
+  // Round-trip the destination so unlocking lands where the operator was going.
+  unlock.searchParams.set('next', pathname + request.nextUrl.search);
+  return NextResponse.redirect(unlock);
+}
+
+export const config = {
+  // Everything except Next's own static output and the favicon. Listing what to
+  // skip (rather than what to guard) is deliberate: a new route is protected by
+  // default instead of protected once someone remembers to add it.
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|icon.svg).*)'],
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "FOUNDER OS — personal operating system and AI agent command center",
   "scripts": {
-    "dev": "next dev -p 4100",
+    "dev": "next dev -H 127.0.0.1 -p 4100",
     "build": "next build",
     "start": "next start -p 4100",
     "test": "vitest run",

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'vitest';
+import { bearerFrom, decideAccess, isPublicPath, safeEqual } from '@/lib/auth';
+
+const TOKEN = 'a'.repeat(32);
+
+describe('decideAccess', () => {
+  test('allows an unconfigured development server so the local demo stays zero-config', () => {
+    expect(
+      decideAccess({
+        token: undefined,
+        presented: undefined,
+        isProduction: false,
+      }),
+    ).toEqual({
+      kind: 'allow',
+    });
+  });
+
+  test('refuses to serve in production when no token is configured', () => {
+    const decision = decideAccess({
+      token: undefined,
+      presented: undefined,
+      isProduction: true,
+    });
+    expect(decision.kind).toBe('misconfigured');
+  });
+
+  test('treats a whitespace-only token as unset', () => {
+    expect(decideAccess({ token: '   ', presented: undefined, isProduction: true }).kind).toBe(
+      'misconfigured',
+    );
+  });
+
+  test('rejects a token too short to resist guessing', () => {
+    expect(decideAccess({ token: 'short', presented: 'short', isProduction: false }).kind).toBe(
+      'misconfigured',
+    );
+  });
+
+  test('allows a matching credential', () => {
+    expect(decideAccess({ token: TOKEN, presented: TOKEN, isProduction: true })).toEqual({
+      kind: 'allow',
+    });
+  });
+
+  test.each([
+    ['no credential', undefined],
+    ['wrong credential', 'b'.repeat(32)],
+    ['empty credential', ''],
+    ['correct prefix only', 'a'.repeat(31)],
+  ])('rejects %s once a token is configured', (_label, presented) => {
+    expect(decideAccess({ token: TOKEN, presented, isProduction: true }).kind).toBe('unauthorized');
+  });
+
+  test('a configured token is enforced in development too', () => {
+    expect(decideAccess({ token: TOKEN, presented: undefined, isProduction: false }).kind).toBe(
+      'unauthorized',
+    );
+  });
+});
+
+describe('safeEqual', () => {
+  test('matches identical strings and rejects everything else', () => {
+    expect(safeEqual('abc', 'abc')).toBe(true);
+    expect(safeEqual('abc', 'abd')).toBe(false);
+    expect(safeEqual('abc', 'ab')).toBe(false);
+    expect(safeEqual('', '')).toBe(true);
+    expect(safeEqual('abc', '')).toBe(false);
+  });
+
+  test('a length mismatch cannot pass by prefix', () => {
+    expect(safeEqual('secret', 'secretsecret')).toBe(false);
+    expect(safeEqual('secretsecret', 'secret')).toBe(false);
+  });
+});
+
+describe('bearerFrom', () => {
+  test('extracts the credential and tolerates casing and padding', () => {
+    expect(bearerFrom('Bearer abc123')).toBe('abc123');
+    expect(bearerFrom('bearer abc123')).toBe('abc123');
+    expect(bearerFrom('  Bearer   abc123  ')).toBe('abc123');
+  });
+
+  test('ignores anything that is not a bearer credential', () => {
+    expect(bearerFrom(null)).toBeUndefined();
+    expect(bearerFrom('')).toBeUndefined();
+    expect(bearerFrom('Basic abc123')).toBeUndefined();
+    expect(bearerFrom('Bearer')).toBeUndefined();
+  });
+});
+
+describe('isPublicPath', () => {
+  test('leaves the unlock exchange reachable so the gate cannot lock everyone out', () => {
+    expect(isPublicPath('/unlock')).toBe(true);
+    expect(isPublicPath('/api/unlock')).toBe(true);
+  });
+
+  test('leaves machine-to-machine webhooks reachable — they carry their own secret', () => {
+    expect(isPublicPath('/api/webhooks/manychat')).toBe(true);
+  });
+
+  test.each(['/', '/agents', '/api/keys', '/api/comms/reply', '/api/agents/broadcast'])(
+    'guards %s',
+    (path) => {
+      expect(isPublicPath(path)).toBe(false);
+    },
+  );
+
+  test('does not let a lookalike prefix escape the gate', () => {
+    expect(isPublicPath('/unlocked-secrets')).toBe(false);
+    expect(isPublicPath('/api/unlockable')).toBe(false);
+  });
+});

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -41,6 +41,7 @@ const PAGES: PageEntry[] = [
   { file: 'analytics/page.tsx', load: () => import('@/app/analytics/page') },
   { file: 'reference/page.tsx', load: () => import('@/app/reference/page') },
   { file: 'personas/page.tsx', load: () => import('@/app/personas/page') },
+  { file: 'unlock/page.tsx', load: () => import('@/app/unlock/page'), props: { searchParams: {} } },
 ];
 
 function discoverPages(dir: string, base = ''): string[] {


### PR DESCRIPTION
Hey — really enjoyed reading this. The connector layer especially: the three-state `ConnectorState` with `error` split from `not_configured`, and `env` injectable with a `process.env` default so the credential paths stay testable. That's a nicer integration boundary than most codebases have.

While reading it I noticed one thing worth fixing, so I wrote the fix rather than just filing an issue. Happy to change any of it, or for you to close this and do it your own way.

## The problem

Every page and API route serves without authentication. On a laptop that's defensible — it's a single-operator app, there's no one to distinguish from.

But `README.md` → **Deploying to Railway** walks an operator through putting that same app on the public internet with live credentials in it. Following those steps exactly, anyone with the URL can:

- `GET /api/keys` — read which secrets are set, plus the last 4 characters of each
- `POST /api/keys` — **overwrite** `STRIPE_SECRET_KEY`, `SLACK_BOT_TOKEN`, and all four `INBOX_*_PASS` values (it writes `.env.local` and mutates `process.env` live)
- `POST /api/comms/reply` — send email over SMTP as you, and post to Slack
- `POST /api/agents/[id]/run` — run any agent and read back whatever it fetched

`next dev` also binds `0.0.0.0`, so a local run is reachable by anyone on the same network.

## The approach

The reason auth is missing from 36 routes isn't 36 oversights — it's that requests go from route straight to repository, so there's no seam where "who is calling this?" could be asked. So this adds the seam rather than 36 guards:

- **`middleware.ts`** in front of everything. The matcher lists what to *skip*, so a new route is protected the moment it exists rather than when someone remembers to guard it.
- **`lib/auth.ts`** holds the decision as a pure function, so it's testable without spinning up Next.

## What changes for you

**Nothing locally.** With `FOUNDER_OS_ACCESS_TOKEN` unset, a dev server behaves exactly as before — `npm install && npm run dev` still boots straight into the seeded demo with no config. That mattered to me; the zero-friction first run is the best thing about this repo and I didn't want to spend it.

**Deployed, a token is required.** A production build with no token set refuses to serve and explains why (503). A missing secret should fail loudly rather than quietly serving your Stripe key to the internet.

Beyond that:

- `/unlock` exchanges the token for an httpOnly, `sameSite=lax` cookie. It's a **server component posting a plain form** — no client JS, and it stays directly invocable so your existing page smoke net still covers it.
- Scripts and agents can send `Authorization: Bearer <token>` instead.
- **`/api/webhooks/*` stays public.** ManyChat can't present your token, and that route already authenticates itself with `MANYCHAT_WEBHOOK_SECRET`. Gating it would have broken the Instagram DM ingest.
- `npm run dev` now binds `127.0.0.1`.
- Token comparison is constant-time. `===` returns on the first differing byte, which leaks a shared secret to anyone willing to measure. Edge runtime has no `node:crypto` `timingSafeEqual`, so it's written by hand.
- `?next=` redirect targets are restricted to same-site paths, so the unlock flow can't be turned into an open redirect.

## Verification

- **892 tests passing** (up from 869; 23 new), `tsc --noEmit` clean, `next build` clean.
- Checked against a running server, before and after: `/api/keys` read and write, `/api/comms/reply`, and page loads all went `200 → 401`; correct token `200`; wrong token `401`; webhook still `200`; unlock form sets the cookie and lands on `?next=`; `//evil.com` as a redirect target collapses to `/`.
- Production build with no token set returns `503` on both a page and an API route.

Two notes while I was in here:

Your completeness meta-tests (`'no page escapes'`, `'no route escapes'`) caught my new page immediately and made me change its design — a client component with hooks isn't directly invocable, so I rewrote `/unlock` as a server component. That test earned its keep; most repos don't have anything like it.

Separately, and out of scope for this PR: the data model has no tenancy columns and credentials live in `process.env`, so Founder OS is single-operator by construction. That's a coherent design — it just means the deploy docs and the architecture were saying different things. I've reflected that in the README's new **Access control** section, but reword it however you like.
