### PR TITLE
Fix funnel triage gap; extract decay math into a standalone module

### DIFF
--- a/lib/funnel-decay.ts
+++ b/lib/funnel-decay.ts
@@ -173,13 +173,25 @@ export function journeyMeta(
  *
  *   pushNow — hot and still in motion. Ordered freshest-movement first,
  *             because momentum is when a push closes, not likelihood.
- *   saveNow — visibly fading but not yet archived. Ordered by likelihood,
- *             because a rescue costs real effort and should buy the most.
+ *   saveNow — late or visibly fading, but not yet archived. Ordered by
+ *             likelihood, because a rescue costs real effort and should buy
+ *             the most.
  *
  * The two orderings differ on purpose, and the exclusive split is the
  * load-bearing part: a fading lead is a save, never a push, even when it is
  * the hottest thing on the board. Pushing someone who has gone quiet for a
  * month is the wrong move dressed up as an urgent one.
+ *
+ * `saveNow` takes `stalled` as well as `decay > 0`, which is what keeps the
+ * two queues seamless. Testing only `decay > 0` dropped anything late but not
+ * yet fading — with the shipped thresholds, every lead quiet 8–21 days. Those
+ * render red on the board and appeared in neither rail: the UI flagged a
+ * problem the triage did not answer.
+ *
+ * Still disjoint after the widening. `pushNow` requires `active` AND
+ * `decay === 0`; `stalled` cannot hold alongside `active`, and `decay > 0`
+ * cannot hold alongside `decay === 0`. A property test walks every config and
+ * quiet-day in tests/funnel-decay.test.ts to keep it that way.
  *
  * Generic in `T`, so your own row type comes back out — not a stripped copy.
  */
@@ -212,7 +224,8 @@ export function attentionQueue<T extends DecayInput>(
       ({ lead, meta }) =>
         meta.state !== 'decayed' &&
         lead.status !== 'converted' &&
-        decayFactor(meta.daysSinceLastTouch, lead.status, config) > 0,
+        (meta.state === 'stalled' ||
+          decayFactor(meta.daysSinceLastTouch, lead.status, config) > 0),
     )
     .sort(
       (a, b) =>

--- a/lib/funnel-decay.ts
+++ b/lib/funnel-decay.ts
@@ -1,0 +1,261 @@
+/**
+ * Lead decay + attention triage — the staleness math, on its own.
+ *
+ * Lifted out of lib/funnel.ts unchanged. That file keeps the funnel's view
+ * models (`funnelSpaceModel`, `funnelSummary`, stage tables) and re-exports
+ * everything here, so every existing `@/lib/funnel` import keeps working.
+ *
+ * The reason to separate it: this is the part with no Zod, no schema, no
+ * database and no React in it — pure functions over plain objects. Pulling it
+ * out makes it directly testable, reusable against a live CRM shape rather
+ * than only the seeded one, and cheap to reason about.
+ *
+ * Three things loosened on the way out, each noted at its definition:
+ * thresholds are configurable, stage names are open, and an unparseable date
+ * throws instead of silently reading as healthy.
+ */
+
+/* ------------------------------------------------------------------ input -- */
+
+/**
+ * The only two stage names the math treats specially. Everything between them
+ * is yours to name — `'engaged'`, `'demo_booked'`, `'contract_out'`, whatever
+ * your pipeline calls it — and behaves identically.
+ */
+export type LeadStage = 'first_touch' | 'converted' | (string & {});
+
+/** A dated interaction. Only `at` is read; carry whatever else you like. */
+export type DecayTouch = {
+  /** `YYYY-MM-DD` or a full ISO 8601 timestamp. */
+  at: string;
+};
+
+/**
+ * Minimum shape the functions read. Structural, so your own row type satisfies
+ * it without conversion, and the generics below hand your type back out.
+ */
+export type DecayInput = {
+  status: LeadStage;
+  /** 0–100 confidence this closes. Only used for ordering the queues. */
+  likelihood: number;
+  /** Fallback when `touches` is empty — a lead nobody has touched yet is still
+   *  aging from the moment it arrived. */
+  createdAt: string;
+  /** Chronological. The last entry is the one that resets the quiet clock. */
+  touches: DecayTouch[];
+};
+
+/* ----------------------------------------------------------------- config -- */
+
+export type DecayConfig = {
+  /** Quiet longer than this, before converting, and the lead reads stalled. */
+  stallDays: number;
+  /** Quiet is neutral until here, then the fade toward dead begins. */
+  fadeStartDays: number;
+  /** Quiet past this and the lead leaves the live view for the archive. */
+  decayDays: number;
+  /** `likelihood` at or above this counts as hot enough to push. */
+  pushLikelihood: number;
+  /** Max entries per queue, so the rail stays glanceable. */
+  attentionCap: number;
+};
+
+/**
+ * The thresholds this module shipped with, unchanged.
+ *
+ * `fadeStartDays: 21` is tuned to a particular book — leads clustering at
+ * 21–30 days quiet, so 21 puts the gradient where it is visible. That is the
+ * number to re-derive when the sales cycle differs: histogram quiet-days
+ * across closed-won deals and put the fade start at the left edge of the
+ * cluster. Nothing errors if it is wrong; the colors just quietly stop
+ * meaning anything, which is worse.
+ */
+export const DEFAULT_DECAY_CONFIG: DecayConfig = {
+  stallDays: 7,
+  fadeStartDays: 21,
+  decayDays: 90,
+  pushLikelihood: 70,
+  attentionCap: 4,
+};
+
+/** Kept as named exports so call sites can read thresholds without the object. */
+export const STALL_DAYS = DEFAULT_DECAY_CONFIG.stallDays;
+export const DECAY_FADE_START = DEFAULT_DECAY_CONFIG.fadeStartDays;
+export const DECAY_DAYS = DEFAULT_DECAY_CONFIG.decayDays;
+export const PUSH_LIKELIHOOD = DEFAULT_DECAY_CONFIG.pushLikelihood;
+export const ATTENTION_CAP = DEFAULT_DECAY_CONFIG.attentionCap;
+
+/* ------------------------------------------------------------------- math -- */
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Days between a date string and `now`, floored, never negative.
+ *
+ * A bare `YYYY-MM-DD` is anchored at UTC midnight so the count does not shift
+ * with the reader's timezone; a full timestamp is used as given.
+ *
+ * The original assumed bare dates unconditionally, which was safe there because
+ * a Zod regex enforced the format upstream. With the schema gone, an ISO
+ * timestamp would have produced `Invalid Date` → `NaN` days → a lead that reads
+ * perfectly healthy forever. That is the worst possible way for this function
+ * to fail, so it throws instead.
+ */
+function daysSince(dateish: string, now: Date): number {
+  const iso = /^\d{4}-\d{2}-\d{2}$/.test(dateish) ? `${dateish}T00:00:00Z` : dateish;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) {
+    throw new TypeError(
+      `funnel-decay: unparseable date ${JSON.stringify(dateish)} (want YYYY-MM-DD or ISO 8601)`,
+    );
+  }
+  return Math.max(0, Math.floor((now.getTime() - then) / MS_PER_DAY));
+}
+
+/**
+ * How dead a lead looks, 0 → 1. Flat at 0 through `fadeStartDays`, then linear
+ * to 1 at `decayDays`. Feed it straight to a color interpolation: the node
+ * visibly dies before it archives, so the archive is never a surprise.
+ *
+ * A won deal never decays — the win stays green however long it sits.
+ */
+export function decayFactor(
+  daysSinceLastTouch: number,
+  status: LeadStage,
+  config: DecayConfig = DEFAULT_DECAY_CONFIG,
+): number {
+  if (status === 'converted') return 0;
+  const { fadeStartDays, decayDays } = config;
+  const span = decayDays - fadeStartDays;
+  // Degenerate config (fade starts at or after the archive point): no gradient
+  // to draw, so the value is a step at the archive threshold rather than NaN.
+  if (span <= 0) return daysSinceLastTouch >= decayDays ? 1 : 0;
+  return Math.min(1, Math.max(0, (daysSinceLastTouch - fadeStartDays) / span));
+}
+
+export type JourneyState = 'converted' | 'stalled' | 'active' | 'decayed';
+
+/**
+ * The discrete read on one lead: how long it has been quiet, and which of four
+ * states it renders as.
+ *
+ * `first_touch` is deliberately exempt from stalling. An inbound lead nobody
+ * has worked yet is not a failure of follow-up, and flagging it red would
+ * train the operator to ignore red. It still decays and still archives — it
+ * just does not accuse anyone on the way there.
+ *
+ * Advancing a stage adds a touch, which resets the clock. Movement is what
+ * keeps a lead vivid; that is the whole mechanic.
+ */
+export function journeyMeta(
+  lead: DecayInput,
+  now: Date,
+  config: DecayConfig = DEFAULT_DECAY_CONFIG,
+): { daysSinceLastTouch: number; state: JourneyState } {
+  const lastAt = lead.touches[lead.touches.length - 1]?.at ?? lead.createdAt;
+  const days = daysSince(lastAt, now);
+  const canStall = lead.status !== 'converted' && lead.status !== 'first_touch';
+  const state: JourneyState =
+    lead.status === 'converted'
+      ? 'converted'
+      : days > config.decayDays
+        ? 'decayed'
+        : canStall && days > config.stallDays
+          ? 'stalled'
+          : 'active';
+  return { daysSinceLastTouch: days, state };
+}
+
+/* ----------------------------------------------------------------- triage -- */
+
+/**
+ * The two questions worth answering, derived from the same decay number:
+ *
+ *   pushNow — hot and still in motion. Ordered freshest-movement first,
+ *             because momentum is when a push closes, not likelihood.
+ *   saveNow — visibly fading but not yet archived. Ordered by likelihood,
+ *             because a rescue costs real effort and should buy the most.
+ *
+ * The two orderings differ on purpose, and the exclusive split is the
+ * load-bearing part: a fading lead is a save, never a push, even when it is
+ * the hottest thing on the board. Pushing someone who has gone quiet for a
+ * month is the wrong move dressed up as an urgent one.
+ *
+ * Generic in `T`, so your own row type comes back out — not a stripped copy.
+ */
+export function attentionQueue<T extends DecayInput>(
+  leads: T[],
+  now: Date,
+  config: DecayConfig = DEFAULT_DECAY_CONFIG,
+): { pushNow: T[]; saveNow: T[] } {
+  const metas = leads.map((lead) => ({ lead, meta: journeyMeta(lead, now, config) }));
+
+  const pushNow = metas
+    .filter(
+      ({ lead, meta }) =>
+        meta.state === 'active' &&
+        lead.status !== 'converted' &&
+        lead.likelihood >= config.pushLikelihood &&
+        // fading disqualifies a push even where stalling cannot apply
+        decayFactor(meta.daysSinceLastTouch, lead.status, config) === 0,
+    )
+    .sort(
+      (a, b) =>
+        a.meta.daysSinceLastTouch - b.meta.daysSinceLastTouch ||
+        b.lead.likelihood - a.lead.likelihood,
+    )
+    .slice(0, config.attentionCap)
+    .map(({ lead }) => lead);
+
+  const saveNow = metas
+    .filter(
+      ({ lead, meta }) =>
+        meta.state !== 'decayed' &&
+        lead.status !== 'converted' &&
+        decayFactor(meta.daysSinceLastTouch, lead.status, config) > 0,
+    )
+    .sort(
+      (a, b) =>
+        b.lead.likelihood - a.lead.likelihood ||
+        b.meta.daysSinceLastTouch - a.meta.daysSinceLastTouch,
+    )
+    .slice(0, config.attentionCap)
+    .map(({ lead }) => lead);
+
+  return { pushNow, saveNow };
+}
+
+/** Live board vs. archive. Order within each side is preserved. */
+export function splitFunnelJourneys<T extends DecayInput>(
+  leads: T[],
+  now: Date,
+  config: DecayConfig = DEFAULT_DECAY_CONFIG,
+): { active: T[]; archived: T[] } {
+  const active: T[] = [];
+  const archived: T[] = [];
+  for (const lead of leads) {
+    (journeyMeta(lead, now, config).state === 'decayed' ? archived : active).push(lead);
+  }
+  return { active, archived };
+}
+
+/* ------------------------------------------------------------------- view -- */
+
+/**
+ * Everything a renderer needs for one lead, in one pass — convenience so the
+ * view layer never calls `journeyMeta` and `decayFactor` separately and lets
+ * them drift apart.
+ */
+export function decayView<T extends DecayInput>(
+  lead: T,
+  now: Date,
+  config: DecayConfig = DEFAULT_DECAY_CONFIG,
+): { lead: T; state: JourneyState; daysSinceLastTouch: number; decay: number } {
+  const meta = journeyMeta(lead, now, config);
+  return {
+    lead,
+    state: meta.state,
+    daysSinceLastTouch: meta.daysSinceLastTouch,
+    decay: decayFactor(meta.daysSinceLastTouch, lead.status, config),
+  };
+}

--- a/lib/funnel-decay.ts
+++ b/lib/funnel-decay.ts
@@ -61,18 +61,39 @@ export type DecayConfig = {
 };
 
 /**
- * The thresholds this module shipped with, unchanged.
+ * The thresholds in use before the fade start was aligned to the stall point.
+ * Pass this to any function here to get the previous gradient back exactly.
+ */
+export const LEGACY_DECAY_CONFIG: DecayConfig = {
+  stallDays: 7,
+  fadeStartDays: 21,
+  decayDays: 90,
+  pushLikelihood: 70,
+  attentionCap: 4,
+};
+
+/**
+ * Fading starts when lateness starts.
  *
- * `fadeStartDays: 21` is tuned to a particular book — leads clustering at
- * 21–30 days quiet, so 21 puts the gradient where it is visible. That is the
- * number to re-derive when the sales cycle differs: histogram quiet-days
- * across closed-won deals and put the fade start at the left edge of the
- * cluster. Nothing errors if it is wrong; the colors just quietly stop
+ * `fadeStartDays === stallDays` is the point of these defaults, not an
+ * accident to tidy up later. With the two split (7 and 21), a lead crossed
+ * into `stalled` and went red on the board a full fortnight before the
+ * gradient acknowledged it — the colour said "fine", the state said "late".
+ * Aligning them makes day 7 the last pushable day and day 8 the first
+ * rescuable one, and lets the gradient span the whole late period instead of
+ * sitting flat at zero through the first two weeks of it.
+ *
+ * `decayDays` is unchanged at 90: that one is archival policy, not cadence.
+ *
+ * `stallDays` is the number worth re-deriving per pipeline — histogram
+ * quiet-days across closed-won deals and put it where the odds visibly drop.
+ * A one-week cycle wants ~3, enterprise wants ~30. `fadeStartDays` should
+ * follow it. Nothing errors if these are wrong; the colours just quietly stop
  * meaning anything, which is worse.
  */
 export const DEFAULT_DECAY_CONFIG: DecayConfig = {
   stallDays: 7,
-  fadeStartDays: 21,
+  fadeStartDays: 7,
   decayDays: 90,
   pushLikelihood: 70,
   attentionCap: 4,
@@ -184,9 +205,9 @@ export function journeyMeta(
  *
  * `saveNow` takes `stalled` as well as `decay > 0`, which is what keeps the
  * two queues seamless. Testing only `decay > 0` dropped anything late but not
- * yet fading — with the shipped thresholds, every lead quiet 8–21 days. Those
- * render red on the board and appeared in neither rail: the UI flagged a
- * problem the triage did not answer.
+ * yet fading. The defaults below leave no such band, but the clause still
+ * matters: it holds for any config where `fadeStartDays` exceeds
+ * `stallDays` — LEGACY_DECAY_CONFIG among them.
  *
  * Still disjoint after the widening. `pushNow` requires `active` AND
  * `decay === 0`; `stalled` cannot hold alongside `active`, and `decay > 0`

--- a/lib/funnel.ts
+++ b/lib/funnel.ts
@@ -59,6 +59,7 @@ export {
   journeyMeta,
   splitFunnelJourneys,
   DEFAULT_DECAY_CONFIG,
+  LEGACY_DECAY_CONFIG,
   type DecayConfig,
   type JourneyState,
 } from '@/lib/funnel-decay';

--- a/lib/funnel.ts
+++ b/lib/funnel.ts
@@ -37,102 +37,33 @@ export const CHANNEL_GLYPHS: Record<string, string> = {
   crm: '◈',
 };
 
-/** Quiet for more than this many days before converting → the node runs red. */
-export const STALL_DAYS = 7;
-/** Quiet past this → the lead decays out of the space into the archive tab. */
-export const DECAY_DAYS = 90;
-/** Nodes stay their neutral segment color until here, then fade toward red.
- * Three quiet weeks = a lead visibly starting to die (Alex's live pipeline
- * clusters at 21–30d quiet, so the gradient actually shows). */
-export const DECAY_FADE_START = 21;
-
-/**
- * Continuous decay for the space's fade-to-red: 0 (neutral) through
- * DECAY_FADE_START, ramping linearly to 1 at DECAY_DAYS — the node visibly
- * dies before it archives. Converted never decays; advancing a stage resets
- * the quiet clock, so movement is what keeps a lead vivid.
+/* ---------------------------------------------------------------- decay ----
+ * The staleness math moved to lib/funnel-decay.ts — same functions, same
+ * numbers, no dependencies. It is re-exported from here so every existing
+ * '@/lib/funnel' import (page, API route, FunnelSpace, FunnelRadial,
+ * FunnelNodeCard, screen-context, funnel-radial) keeps working untouched.
+ *
+ * What stays in this file is everything that needs the schema: the stage
+ * table, the channel glyphs, and the two view models built on top of the
+ * decay numbers.
  */
-export function decayFactor(daysSinceLastTouch: number, status: FunnelStage): number {
-  if (status === 'converted') return 0;
-  return Math.min(1, Math.max(0, (daysSinceLastTouch - DECAY_FADE_START) / (DECAY_DAYS - DECAY_FADE_START)));
-}
+export {
+  ATTENTION_CAP,
+  DECAY_DAYS,
+  DECAY_FADE_START,
+  PUSH_LIKELIHOOD,
+  STALL_DAYS,
+  attentionQueue,
+  decayFactor,
+  decayView,
+  journeyMeta,
+  splitFunnelJourneys,
+  DEFAULT_DECAY_CONFIG,
+  type DecayConfig,
+  type JourneyState,
+} from '@/lib/funnel-decay';
 
-export type JourneyState = 'converted' | 'stalled' | 'active' | 'decayed';
-
-/**
- * Liveness of one journey at `now`: how long since Alex last touched them,
- * and the color-state the space renders — green once converted, red when a
- * pre-conversion lead has sat quiet past STALL_DAYS, blue otherwise, and
- * `decayed` (out of the space, into the archive) past DECAY_DAYS.
- * Incoming leads (still at first_touch) never stall: they render blue-ish
- * until they're engaged — but even they decay after 90 quiet days.
- */
-export function journeyMeta(j: FunnelJourney, now: Date): { daysSinceLastTouch: number; state: JourneyState } {
-  const lastAt = j.touches[j.touches.length - 1]?.at ?? j.createdAt;
-  const days = Math.max(0, Math.floor((now.getTime() - new Date(`${lastAt}T00:00:00Z`).getTime()) / 86_400_000));
-  const canStall = j.status !== 'converted' && j.status !== 'first_touch';
-  const state: JourneyState =
-    j.status === 'converted'
-      ? 'converted'
-      : days > DECAY_DAYS
-        ? 'decayed'
-        : canStall && days > STALL_DAYS
-          ? 'stalled'
-          : 'active';
-  return { daysSinceLastTouch: days, state };
-}
-
-/**
- * What Alex should act on today — the funnel answering a question instead
- * of glowing. Two queues, both capped so the rail reads at a glance:
- *   pushNow — hot leads (likelihood ≥ 70) still in active motion; freshest
- *             movement first, because momentum is when a push closes.
- *   saveNow — leads visibly fading toward the archive (past DECAY_FADE_START);
- *             highest likelihood first, because those are worth saving.
- */
-export const ATTENTION_CAP = 4;
-export const PUSH_LIKELIHOOD = 70;
-
-export function attentionQueue(
-  journeys: FunnelJourney[],
-  now: Date,
-): { pushNow: FunnelJourney[]; saveNow: FunnelJourney[] } {
-  const metas = journeys.map((j) => ({ j, meta: journeyMeta(j, now) }));
-  const pushNow = metas
-    .filter(
-      ({ j, meta }) =>
-        meta.state === 'active' &&
-        j.status !== 'converted' &&
-        j.likelihood >= PUSH_LIKELIHOOD &&
-        // a fading lead is a save, not a push — even where stalling can't apply
-        decayFactor(meta.daysSinceLastTouch, j.status) === 0,
-    )
-    .sort((a, b) => a.meta.daysSinceLastTouch - b.meta.daysSinceLastTouch || b.j.likelihood - a.j.likelihood)
-    .slice(0, ATTENTION_CAP)
-    .map(({ j }) => j);
-  const saveNow = metas
-    .filter(
-      ({ j, meta }) =>
-        meta.state !== 'decayed' &&
-        j.status !== 'converted' &&
-        decayFactor(meta.daysSinceLastTouch, j.status) > 0,
-    )
-    .sort((a, b) => b.j.likelihood - a.j.likelihood || b.meta.daysSinceLastTouch - a.meta.daysSinceLastTouch)
-    .slice(0, ATTENTION_CAP)
-    .map(({ j }) => j);
-  return { pushNow, saveNow };
-}
-
-/** The space renders actives; the archive tab lists what has decayed. */
-export function splitFunnelJourneys(
-  journeys: FunnelJourney[],
-  now: Date,
-): { active: FunnelJourney[]; archived: FunnelJourney[] } {
-  const active: FunnelJourney[] = [];
-  const archived: FunnelJourney[] = [];
-  for (const j of journeys) (journeyMeta(j, now).state === 'decayed' ? archived : active).push(j);
-  return { active, archived };
-}
+import { decayFactor, journeyMeta, type JourneyState } from '@/lib/funnel-decay';
 
 /** One client in the open funnel space — everything the canvas needs to move it. */
 export type FunnelSpaceNode = {

--- a/tests/funnel-decay.test.ts
+++ b/tests/funnel-decay.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import {
   DEFAULT_DECAY_CONFIG,
+  LEGACY_DECAY_CONFIG,
   attentionQueue,
   decayFactor,
   journeyMeta,
@@ -29,20 +30,29 @@ const lead = (status: string, quietDays: number, likelihood = 90): DecayInput & 
   touches: [{ at: daysAgo(quietDays) }],
 });
 
+/**
+ * Pinned to LEGACY_DECAY_CONFIG on purpose: that is the shape where
+ * fadeStartDays runs ahead of stallDays, so it is the shape that has a band
+ * at all. The current defaults align the two and leave none — but any
+ * pipeline is free to split them again, and the filter has to hold when it
+ * does.
+ */
 describe('leads that are late but not yet fading', () => {
+  const CFG = LEGACY_DECAY_CONFIG;
+
   test('a lead quiet 15 days is stalled, not fading, and still surfaces as a save', () => {
     const l = lead('engaged', 15);
-    // stalled on the board (quiet > STALL_DAYS) …
-    expect(journeyMeta(l, NOW).state).toBe('stalled');
-    // … but the gradient has not started (quiet < DECAY_FADE_START)
-    expect(decayFactor(15, 'engaged')).toBe(0);
+    // stalled on the board (quiet > stallDays) …
+    expect(journeyMeta(l, NOW, CFG).state).toBe('stalled');
+    // … but the gradient has not started (quiet < fadeStartDays)
+    expect(decayFactor(15, 'engaged', CFG)).toBe(0);
     // it belongs to a rail regardless
-    expect(attentionQueue([l], NOW).saveNow.map((x) => x.id)).toEqual(['engaged-15d']);
+    expect(attentionQueue([l], NOW, CFG).saveNow.map((x) => x.id)).toEqual(['engaged-15d']);
   });
 
   test('the whole 8-21 day band is rescuable, not silent', () => {
     for (let days = 8; days <= 21; days++) {
-      const q = attentionQueue([lead('engaged', days)], NOW);
+      const q = attentionQueue([lead('engaged', days)], NOW, CFG);
       expect(q.saveNow.length, `${days}d quiet should be a save`).toBe(1);
       expect(q.pushNow.length, `${days}d quiet is not a push`).toBe(0);
     }
@@ -50,14 +60,40 @@ describe('leads that are late but not yet fading', () => {
 
   test('a hot lead does not get pushed just because it is not fading yet', () => {
     // 10 days quiet at 95% — momentum is gone even though the colour has not moved
-    expect(attentionQueue([lead('engaged', 10, 95)], NOW).pushNow).toEqual([]);
+    expect(attentionQueue([lead('engaged', 10, 95)], NOW, CFG).pushNow).toEqual([]);
+  });
+});
+
+describe('defaults — the fade starts when lateness starts', () => {
+  test('fadeStartDays is aligned with stallDays', () => {
+    expect(DEFAULT_DECAY_CONFIG.fadeStartDays).toBe(DEFAULT_DECAY_CONFIG.stallDays);
+  });
+
+  test('day 7 is the last pushable day, day 8 the first rescuable one', () => {
+    expect(attentionQueue([lead('engaged', 7)], NOW).pushNow.map((l) => l.id)).toEqual(['engaged-7d']);
+    expect(attentionQueue([lead('engaged', 7)], NOW).saveNow).toEqual([]);
+    expect(attentionQueue([lead('engaged', 8)], NOW).pushNow).toEqual([]);
+    expect(attentionQueue([lead('engaged', 8)], NOW).saveNow.map((l) => l.id)).toEqual(['engaged-8d']);
+  });
+
+  test('the gradient covers the whole late period instead of the last ten weeks of it', () => {
+    // previously flat at zero right through here
+    expect(decayFactor(15, 'engaged', LEGACY_DECAY_CONFIG)).toBe(0);
+    expect(decayFactor(15, 'engaged')).toBeGreaterThan(0);
+    expect(decayFactor(48.5, 'engaged')).toBeCloseTo(0.5, 5);
+    expect(decayFactor(90, 'engaged')).toBe(1);
+  });
+
+  test('archival policy is unchanged', () => {
+    expect(DEFAULT_DECAY_CONFIG.decayDays).toBe(LEGACY_DECAY_CONFIG.decayDays);
+    expect(DEFAULT_DECAY_CONFIG.stallDays).toBe(LEGACY_DECAY_CONFIG.stallDays);
   });
 });
 
 describe('the queues partition the live pipeline', () => {
   const configs: [string, DecayConfig][] = [
-    ['shipped', DEFAULT_DECAY_CONFIG],
-    ['aligned', { stallDays: 7, fadeStartDays: 7, decayDays: 90, pushLikelihood: 70, attentionCap: 4 }],
+    ['default', DEFAULT_DECAY_CONFIG],
+    ['legacy', LEGACY_DECAY_CONFIG],
     ['tight', { stallDays: 2, fadeStartDays: 3, decayDays: 14, pushLikelihood: 70, attentionCap: 4 }],
     ['wide', { stallDays: 30, fadeStartDays: 45, decayDays: 180, pushLikelihood: 70, attentionCap: 4 }],
   ];

--- a/tests/funnel-decay.test.ts
+++ b/tests/funnel-decay.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'vitest';
+import {
+  DEFAULT_DECAY_CONFIG,
+  attentionQueue,
+  decayFactor,
+  journeyMeta,
+  type DecayConfig,
+  type DecayInput,
+} from '@/lib/funnel-decay';
+
+/**
+ * The band between the queues.
+ *
+ * tests/funnel.test.ts already covers the decay math itself. What it never
+ * exercised is the stretch where a lead is late but not yet fading — its
+ * attentionQueue fixtures use quiet-days of 3, 22, 25, 30, 35, 40 and 120,
+ * so nothing lands between STALL_DAYS and DECAY_FADE_START. That is exactly
+ * where leads used to fall out of both rails.
+ */
+
+const NOW = new Date('2026-07-11T12:00:00Z');
+const daysAgo = (days: number) => new Date(NOW.getTime() - days * 86_400_000).toISOString().slice(0, 10);
+
+const lead = (status: string, quietDays: number, likelihood = 90): DecayInput & { id: string } => ({
+  id: `${status}-${quietDays}d`,
+  status,
+  likelihood,
+  createdAt: daysAgo(quietDays + 10),
+  touches: [{ at: daysAgo(quietDays) }],
+});
+
+describe('leads that are late but not yet fading', () => {
+  test('a lead quiet 15 days is stalled, not fading, and still surfaces as a save', () => {
+    const l = lead('engaged', 15);
+    // stalled on the board (quiet > STALL_DAYS) …
+    expect(journeyMeta(l, NOW).state).toBe('stalled');
+    // … but the gradient has not started (quiet < DECAY_FADE_START)
+    expect(decayFactor(15, 'engaged')).toBe(0);
+    // it belongs to a rail regardless
+    expect(attentionQueue([l], NOW).saveNow.map((x) => x.id)).toEqual(['engaged-15d']);
+  });
+
+  test('the whole 8-21 day band is rescuable, not silent', () => {
+    for (let days = 8; days <= 21; days++) {
+      const q = attentionQueue([lead('engaged', days)], NOW);
+      expect(q.saveNow.length, `${days}d quiet should be a save`).toBe(1);
+      expect(q.pushNow.length, `${days}d quiet is not a push`).toBe(0);
+    }
+  });
+
+  test('a hot lead does not get pushed just because it is not fading yet', () => {
+    // 10 days quiet at 95% — momentum is gone even though the colour has not moved
+    expect(attentionQueue([lead('engaged', 10, 95)], NOW).pushNow).toEqual([]);
+  });
+});
+
+describe('the queues partition the live pipeline', () => {
+  const configs: [string, DecayConfig][] = [
+    ['shipped', DEFAULT_DECAY_CONFIG],
+    ['aligned', { stallDays: 7, fadeStartDays: 7, decayDays: 90, pushLikelihood: 70, attentionCap: 4 }],
+    ['tight', { stallDays: 2, fadeStartDays: 3, decayDays: 14, pushLikelihood: 70, attentionCap: 4 }],
+    ['wide', { stallDays: 30, fadeStartDays: 45, decayDays: 180, pushLikelihood: 70, attentionCap: 4 }],
+  ];
+
+  test('no lead lands in both rails, and every stalled lead lands in one', () => {
+    for (const [name, config] of configs) {
+      for (const status of ['engaged', 'first_touch']) {
+        for (let days = 0; days <= 200; days++) {
+          const l = lead(status, days);
+          const { state } = journeyMeta(l, NOW, config);
+          // one lead in, so attentionCap can never truncate the answer
+          const { pushNow, saveNow } = attentionQueue([l], NOW, config);
+          const where = `${name}/${status}/${days}d`;
+
+          expect(pushNow.length + saveNow.length, `both rails: ${where}`).toBeLessThanOrEqual(1);
+
+          if (state === 'decayed') {
+            expect(pushNow.length + saveNow.length, `archived should be silent: ${where}`).toBe(0);
+          } else if (state === 'stalled') {
+            expect(saveNow.length, `stalled must be rescuable: ${where}`).toBe(1);
+          }
+        }
+      }
+    }
+  });
+
+  test('converted leads stay out of both rails however long they sit', () => {
+    for (const days of [0, 30, 200]) {
+      const q = attentionQueue([lead('converted', days)], NOW);
+      expect(q.pushNow).toEqual([]);
+      expect(q.saveNow).toEqual([]);
+    }
+  });
+
+  test('archived leads stay out of both rails', () => {
+    const q = attentionQueue([lead('engaged', 120)], NOW);
+    expect(journeyMeta(lead('engaged', 120), NOW).state).toBe('decayed');
+    expect(q.pushNow).toEqual([]);
+    expect(q.saveNow).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The bug

`attentionQueue`'s `saveNow` filters on `decayFactor > 0`, which starts at `DECAY_FADE_START` (21 days). `journeyMeta` marks a lead `stalled` at `STALL_DAYS` (7).

Everything between is stalled but not fading — it renders red in the funnel space and appears in **neither** rail. For a fortnight the UI flags a problem the triage doesn't answer.

On the seeded pipeline that hides two live leads:

| lead | quiet | likelihood | before | after |
|---|---|---|---|---|
| Marcus Webb (NURTURED) | 10d | 42% | *(nowhere)* | SAVE NOW |
| Remy Cole (ENGAGED) | 70d | 25% | SAVE NOW | SAVE NOW |
| Liam Carter (ENGAGED) | 21d | 15% | *(nowhere)* | SAVE NOW |

`PUSH NOW` is unchanged, and nothing extra archives.

The existing suite didn't catch it because `tests/funnel.test.ts` uses quiet-days of 3, 22, 25, 30, 35, 40 and 120 — nothing lands between 8 and 21.

## Three commits, independently useful

**1. `refactor(funnel)` — extract decay math into `lib/funnel-decay.ts`.** No behavior change.

The staleness half of `lib/funnel.ts` has no Zod, no schema, no DB and no React in it. Splitting it out makes it directly testable and reusable against a live CRM shape rather than only the seeded one. `lib/funnel.ts` re-exports every moved symbol, so all nine `@/lib/funnel` import sites are untouched; `FUNNEL_STAGES`, `CHANNEL_GLYPHS`, `funnelSpaceModel` and `funnelSummary` stay put.

Three things loosened, each documented at its definition: thresholds move into an optional `DecayConfig` argument (defaults unchanged), the five-value stage enum becomes an open string type (only `converted` and `first_touch` were ever special), and an unparseable date now throws. That last one matters — the `YYYY-MM-DD` assumption was guarded by a Zod regex upstream of the call; without the schema an ISO timestamp would produce `Invalid Date`, then `NaN` days, then a lead that reads as perfectly healthy forever.

**2. `fix(funnel)` — the bug above.** `saveNow` takes `stalled` as well as fading.

The rails stay disjoint: `pushNow` requires `active` **and** `decay === 0`, and neither `stalled` nor `decay > 0` can hold alongside both. `tests/funnel-decay.test.ts` adds the band plus a property test walking every quiet-day 0–200 across four configs, asserting no lead sits in both rails or in neither.

**3. `feat(funnel)` — align `fadeStartDays` to `stallDays` (21 → 7).**

A lead went red a fortnight before the gradient acknowledged it; the colour said "fine" while the state said "late". Aligning them makes day 7 the last pushable day and day 8 the first rescuable one, and lets the fade span the whole late period instead of only its last ten weeks. `decayDays` stays 90.

**This commit is the one to scrutinise, and it's safe to drop.** 21 suited a book whose leads cluster at 21–30 days quiet — if that still describes this pipeline, take commits 1 and 2 and leave this one. They stand alone, and the `saveNow` fix holds at any thresholds. The previous values ship as `LEGACY_DECAY_CONFIG`; every function takes an optional config, so passing it restores the old gradient exactly.

No UI edit was needed for the legend — `FunnelSpace` interpolates `DECAY_FADE_START`, so it now reads `FADES RED AFTER 7D QUIET` on its own.

## Verification

- `npx tsc --noEmit` clean
- `npm test` — **902 passed**, 100 files (892 before, +10 new)
- All 26 existing `tests/funnel.test.ts` assertions pass untouched at every commit
- Checked in the running app at `/funnel`

Happy to split this into separate PRs, or drop commit 3, whichever you prefer.