### PR TITLE
perf(growth): find window baseline without copying the series

### DIFF
--- a/lib/growth.ts
+++ b/lib/growth.ts
@@ -20,7 +20,15 @@ export function windowDelta(points: GrowthPoint[], days: number): { current: num
   if (points.length < 2) return null;
   const latest = points[points.length - 1];
   const windowStart = dateMs(latest.capturedAt) - days * DAY_MS;
-  const baseline = [...points].reverse().find((p) => dateMs(p.capturedAt) <= windowStart);
+  // Points are sorted oldest -> newest, so walk backwards for the newest point
+  // at/before the window start. Avoids copying and reversing the whole series.
+  let baseline: GrowthPoint | undefined;
+  for (let i = points.length - 1; i >= 0; i--) {
+    if (dateMs(points[i].capturedAt) <= windowStart) {
+      baseline = points[i];
+      break;
+    }
+  }
   if (!baseline || baseline.value === 0) return null;
   return { current: latest.value, baseline: baseline.value };
 }


### PR DESCRIPTION
Small one-function change in `lib/growth.ts`.

`windowDelta()` located the baseline snapshot with:

```ts
const baseline = [...points].reverse().find((p) => dateMs(p.capturedAt) <= windowStart);
```

That allocates a full copy of the series and reverses it on every call. The doc comment above the module already guarantees points are sorted oldest to newest, so a backwards walk finds the exact same point with no allocation and stops as soon as it hits one.

It runs more than once per view: `lib/email-list.ts` calls `growthOver` three times per list (7/30/60d), and `lib/social.ts` calls it per account and again per merged series.

**No behaviour change.** Same point selected, same null handling.

Verified locally:
- `npm test` — 950 tests across 109 files, all passing (`tests/growth.test.ts` covers this function directly and was not touched)
- `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187Hc27vXpZ91D5pserJBKD