### PR TITLE
Security fixes: fail-closed gate, per-route auth, relay + LLM throttling

### DIFF
--- a/app/api/agents/[id]/chat/route.ts
+++ b/app/api/agents/[id]/chat/route.ts
@@ -3,11 +3,23 @@ import { getDb } from '@/lib/data';
 import { realAgents } from '@/lib/agents/real';
 import { chatWithAgent } from '@/lib/agents/chat';
 import { routeConductorMessage } from '@/lib/agents/conductor';
+import { requireSession } from '@/lib/session';
+import { rateLimit, tooManyRequests } from '@/lib/rate-limit';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs'; // better-sqlite3 is native — keep off the edge runtime
 
+const MINUTE = 60 * 1000;
+const DAY = 24 * 60 * MINUTE;
+// This endpoint spends real money per call (Vercel AI Gateway). Cap the rate and
+// put a hard daily ceiling on total calls as a cost cap; both overridable.
+const CHAT_PER_MINUTE = Number(process.env.AGENT_CHAT_MAX_PER_MIN ?? 10);
+const CHAT_PER_DAY = Number(process.env.AGENT_CHAT_MAX_PER_DAY ?? 300);
+
 export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const gate = requireSession(req);
+  if (gate) return gate;
+
   let message = '';
   let screenContext: string | undefined;
   try {
@@ -29,12 +41,22 @@ export async function POST(req: Request, { params }: { params: { id: string } })
     return NextResponse.json({ error: `unknown agent: ${params.id}` }, { status: 404 });
   }
 
+  // Only real chat attempts consume quota (malformed/unknown requests above do
+  // not). Rate + daily cost cap gate the paid LLM call.
+  const perMinute = rateLimit('agent:chat:min', CHAT_PER_MINUTE, MINUTE);
+  if (!perMinute.ok) return tooManyRequests(perMinute.retryAfter);
+  const perDay = rateLimit('agent:chat:day', CHAT_PER_DAY, DAY);
+  if (!perDay.ok) return tooManyRequests(perDay.retryAfter);
+
   try {
     const result = isConductor
       ? await routeConductorMessage(getDb(), realAgents, message, { screenContext })
       : await chatWithAgent(getDb(), realAgents, params.id, message, { screenContext });
     return NextResponse.json(result);
   } catch (err) {
-    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+    // Log the detail server-side; return a generic message so gateway/internal
+    // errors don't leak to the client.
+    console.error('agent chat failed', err);
+    return NextResponse.json({ error: 'chat failed' }, { status: 500 });
   }
 }

--- a/app/api/agents/[id]/run/route.ts
+++ b/app/api/agents/[id]/run/route.ts
@@ -2,18 +2,21 @@ import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/data';
 import { createRuntime } from '@/lib/agents/runtime';
 import { realAgents } from '@/lib/agents/real';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
-export async function POST(_req: Request, { params }: { params: { id: string } }) {
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const gate = requireSession(req);
+  if (gate) return gate;
+
   const runtime = createRuntime(getDb(), realAgents);
   try {
     const run = await runtime.run(params.id);
     return NextResponse.json({ run });
   } catch (err) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : String(err) },
-      { status: 404 },
-    );
+    // Generic message to the client; detail stays server-side.
+    console.error('agent run failed', err);
+    return NextResponse.json({ error: 'agent run failed' }, { status: 404 });
   }
 }

--- a/app/api/agents/broadcast/route.ts
+++ b/app/api/agents/broadcast/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/data';
 import { createRuntime } from '@/lib/agents/runtime';
 import { realAgents } from '@/lib/agents/real';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -10,6 +11,9 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
+  const gate = requireSession(req);
+  if (gate) return gate;
+
   let message = '';
   try {
     const body = (await req.json()) as { message?: unknown };

--- a/app/api/agents/work/route.ts
+++ b/app/api/agents/work/route.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { getDb } from '@/lib/data';
 import { isValidCron } from '@/lib/cron';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,6 +28,9 @@ const CreateSchema = z.discriminatedUnion('kind', [
 ]);
 
 export async function POST(request: Request) {
+  const gate = requireSession(request);
+  if (gate) return gate;
+
   const parsed = CreateSchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
   const db = getDb();
@@ -52,6 +56,9 @@ const PatchSchema = z.discriminatedUnion('kind', [
 ]);
 
 export async function PATCH(request: Request) {
+  const gate = requireSession(request);
+  if (gate) return gate;
+
   const parsed = PatchSchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
   const db = getDb();
@@ -63,6 +70,9 @@ export async function PATCH(request: Request) {
 const DeleteSchema = z.object({ kind: z.enum(['task', 'cron']), id: z.string().min(1) });
 
 export async function DELETE(request: Request) {
+  const gate = requireSession(request);
+  if (gate) return gate;
+
   const parsed = DeleteSchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
   const db = getDb();

--- a/app/api/brain/dump/route.ts
+++ b/app/api/brain/dump/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { ingestBrainDump } from '@/lib/brain-dump';
 import { createGBrainProvider, type CaptureInput } from '@/lib/connectors/gbrain';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,6 +14,9 @@ const DumpSchema = z.object({
 });
 
 export async function POST(request: Request) {
+  const gate = requireSession(request);
+  if (gate) return gate;
+
   const parsed = DumpSchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });

--- a/app/api/comms/email/action/route.ts
+++ b/app/api/comms/email/action/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { updateEmailThread } from '@/lib/connectors/email';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,6 +13,9 @@ const ActionSchema = z.object({
 });
 
 export async function POST(request: Request) {
+  const gate = requireSession(request);
+  if (gate) return gate;
+
   const parsed = ActionSchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
   const { account, ...operation } = parsed.data;

--- a/app/api/comms/reply/route.ts
+++ b/app/api/comms/reply/route.ts
@@ -2,8 +2,18 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { sendSlackMessage } from '@/lib/connectors/slack';
 import { sendEmailReply } from '@/lib/connectors/email';
+import { requireSession } from '@/lib/session';
+import { rateLimit, tooManyRequests } from '@/lib/rate-limit';
 
 export const dynamic = 'force-dynamic';
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+// Send throttles for the real SMTP relay. Overridable via env for higher-volume
+// operators; the defaults keep a leaked/abused endpoint from blasting mail.
+const PER_RECIPIENT_PER_HOUR = Number(process.env.COMMS_REPLY_MAX_PER_RECIPIENT_PER_HOUR ?? 5);
+const GLOBAL_PER_HOUR = Number(process.env.COMMS_REPLY_MAX_PER_HOUR ?? 30);
+const DAILY_CAP = Number(process.env.COMMS_REPLY_MAX_PER_DAY ?? 100);
 
 /**
  * Replies the server can actually deliver. Slack sends via the bot token; email
@@ -25,6 +35,9 @@ const ReplySchema = z.discriminatedUnion('source', [
 ]);
 
 export async function POST(request: Request) {
+  const gate = requireSession(request);
+  if (gate) return gate;
+
   const parsed = ReplySchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
@@ -34,6 +47,15 @@ export async function POST(request: Request) {
     const result = await sendSlackMessage(parsed.data.channel, parsed.data.text);
     return NextResponse.json(result, { status: result.ok ? 200 : 502 });
   }
+
+  // Real SMTP send: throttle per-recipient, globally, and against a daily cap
+  // so the relay can't be used to blast arbitrary addresses.
+  const daily = rateLimit('comms:reply:day', DAILY_CAP, DAY);
+  if (!daily.ok) return tooManyRequests(daily.retryAfter);
+  const global = rateLimit('comms:reply:hour', GLOBAL_PER_HOUR, HOUR);
+  if (!global.ok) return tooManyRequests(global.retryAfter);
+  const recipient = rateLimit(`comms:reply:to:${parsed.data.to.toLowerCase()}`, PER_RECIPIENT_PER_HOUR, HOUR);
+  if (!recipient.ok) return tooManyRequests(recipient.retryAfter);
 
   const result = await sendEmailReply({
     accountId: parsed.data.account,

--- a/app/api/connections/connect/route.ts
+++ b/app/api/connections/connect/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { INTEGRATIONS, connectKeysFor } from '@/lib/integrations-catalog';
 import { readEnvLocal, upsertEnvLocal, removeEnvLocal } from '@/lib/creds';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -26,6 +27,9 @@ function entryFor(slug: string) {
 }
 
 export async function POST(req: Request) {
+  const gate = requireSession(req);
+  if (gate) return gate;
+
   let body: z.infer<typeof ConnectBody>;
   try {
     body = ConnectBody.parse(await req.json());
@@ -59,6 +63,9 @@ export async function POST(req: Request) {
 }
 
 export async function DELETE(req: Request) {
+  const gate = requireSession(req);
+  if (gate) return gate;
+
   let body: z.infer<typeof DisconnectBody>;
   try {
     body = DisconnectBody.parse(await req.json());

--- a/app/api/contacts/tags/route.ts
+++ b/app/api/contacts/tags/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getDb } from '@/lib/data';
 import { CONTACT_TIERS } from '@/lib/life-map';
 import { ContactTagSchema } from '@/lib/schemas';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,6 +12,9 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
+  const gate = requireSession(request);
+  if (gate) return gate;
+
   const parsed = ContactTagSchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
@@ -22,6 +26,9 @@ export async function POST(request: Request) {
 const RemoveSchema = z.object({ person: z.string().min(1), channel: z.string().min(1) });
 
 export async function DELETE(request: Request) {
+  const gate = requireSession(request);
+  if (gate) return gate;
+
   const parsed = RemoveSchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });

--- a/app/api/finances/bank-statement/route.ts
+++ b/app/api/finances/bank-statement/route.ts
@@ -2,9 +2,18 @@ import { NextResponse } from 'next/server';
 import { execFile } from 'node:child_process';
 import { parseBankStatementSummary } from '@/lib/bank-statements';
 import { openBankStore } from '@/lib/bank';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
+
+// Reject anything larger than this before spawning pdftotext on it.
+const MAX_PDF_BYTES = 15 * 1024 * 1024;
+// PDFs begin with "%PDF-" — content-sniff so we never hand a non-PDF (or a
+// disguised payload) to the external extractor.
+function looksLikePdf(buf: Buffer): boolean {
+  return buf.length >= 5 && buf.subarray(0, 5).toString('latin1') === '%PDF-';
+}
 
 // Extract text from a PDF via the system `pdftotext` (poppler). Tries PATH then
 // common Homebrew/usr-local locations; -layout keeps the summary columns aligned.
@@ -32,6 +41,9 @@ function pdfToText(buf: Buffer): Promise<string> {
 /** Accept a bank-statement PDF, extract its summary (income/outflow per business
     per month), and upsert it into the bank store. Idempotent by account+month. */
 export async function POST(req: Request) {
+  const gate = requireSession(req);
+  if (gate) return gate;
+
   const ctype = req.headers.get('content-type') ?? '';
   let buf: Buffer | null = null;
   try {
@@ -49,12 +61,20 @@ export async function POST(req: Request) {
   if (!buf || buf.length === 0) {
     return NextResponse.json({ error: 'expected a PDF upload (file field or PDF body)' }, { status: 400 });
   }
+  if (buf.length > MAX_PDF_BYTES) {
+    return NextResponse.json({ error: 'PDF too large (max 15 MB)' }, { status: 413 });
+  }
+  if (!looksLikePdf(buf)) {
+    return NextResponse.json({ error: 'not a PDF' }, { status: 400 });
+  }
 
   let text: string;
   try {
     text = await pdfToText(buf);
   } catch (e) {
-    return NextResponse.json({ error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+    // Generic to the client; extractor detail (paths, stderr) stays server-side.
+    console.error('pdftotext failed', e);
+    return NextResponse.json({ error: 'failed to read the PDF' }, { status: 500 });
   }
 
   const summary = parseBankStatementSummary(text);

--- a/app/api/finances/statements/route.ts
+++ b/app/api/finances/statements/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { parseStatementCsv, categorize, type LedgerRow } from '@/lib/statements';
 import { openLedger } from '@/lib/ledger';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -8,6 +9,9 @@ export const dynamic = 'force-dynamic';
     text/csv body), parse + categorize it, persist to the separate ledger store,
     and report what landed. Non-CSV / unparseable → 400, never a silent success. */
 export async function POST(req: Request) {
+  const gate = requireSession(req);
+  if (gate) return gate;
+
   const ctype = req.headers.get('content-type') ?? '';
   let text: string | null = null;
   try {

--- a/app/api/keys/route.ts
+++ b/app/api/keys/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import path from 'node:path';
 import { z } from 'zod';
 import { KEY_SLOTS, listKeyStatuses, upsertEnvLocal } from '@/lib/keys';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -18,6 +19,9 @@ const SetKeySchema = z.object({
 });
 
 export async function POST(request: Request) {
+  const gate = requireSession(request);
+  if (gate) return gate;
+
   const parsed = SetKeySchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });

--- a/app/api/lead-magnets/[id]/route.ts
+++ b/app/api/lead-magnets/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getDb } from '@/lib/data';
 import { LeadMagnetStatusSchema } from '@/lib/schemas';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -25,6 +26,9 @@ const PatchSchema = z
   .partial();
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const gate = requireSession(req);
+  if (gate) return gate;
+
   const parsed = PatchSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
 
@@ -39,7 +43,10 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
   return NextResponse.json({ leadMagnet: updated });
 }
 
-export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const gate = requireSession(req);
+  if (gate) return gate;
+
   const removed = getDb().leadMagnets.remove(params.id);
   if (!removed) return NextResponse.json({ error: 'lead magnet not found' }, { status: 404 });
   return NextResponse.json({ ok: true, id: params.id });

--- a/app/api/lead-magnets/route.ts
+++ b/app/api/lead-magnets/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getDb } from '@/lib/data';
 import { LeadMagnetStatusSchema } from '@/lib/schemas';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -42,6 +43,9 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
+  const gate = requireSession(req);
+  if (gate) return gate;
+
   const parsed = CreateSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });

--- a/app/api/social/dm/reply/route.ts
+++ b/app/api/social/dm/reply/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getDb } from '@/lib/data';
 import { sendManyChatText } from '@/lib/connectors/manychat';
 import type { SocialDmMessage } from '@/lib/schemas';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -18,6 +19,9 @@ const ReplySchema = z.object({
  * a reply that didn't actually go out.
  */
 export async function POST(request: Request): Promise<Response> {
+  const gate = requireSession(request);
+  if (gate) return gate;
+
   const parsed = ReplySchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) {
     return NextResponse.json({ ok: false, error: parsed.error.flatten() }, { status: 400 });

--- a/app/api/social/posts/route.ts
+++ b/app/api/social/posts/route.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { getDb } from '@/lib/data';
 import { SocialPlatformSchema, type SocialPost } from '@/lib/schemas';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -24,6 +25,9 @@ const CreateSchema = z.object({
  * up. Wiring an actual Zernio publish is a deliberate later step.
  */
 export async function POST(request: Request) {
+  const gate = requireSession(request);
+  if (gate) return gate;
+
   const parsed = CreateSchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
 

--- a/app/api/social/sync/route.ts
+++ b/app/api/social/sync/route.ts
@@ -2,11 +2,13 @@ import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/data';
 import { syncFromZernioLive } from '@/lib/social-live';
 import { zernioLiveAccounts } from '@/lib/connectors/zernio';
+import { requireSession } from '@/lib/session';
 
 export const dynamic = 'force-dynamic';
 
 /** Force a live follower-count sync from Zernio/Late and report what landed.
-    GET and POST both work so it's trivial to trigger from a browser or curl. */
+    POST only: this mutates state, so it must not be reachable via a top-level
+    GET (SameSite=Lax would attach the gate cookie to a cross-site GET). */
 async function runSync() {
   const db = getDb();
   const accounts = await zernioLiveAccounts();
@@ -20,10 +22,8 @@ async function runSync() {
   });
 }
 
-export async function POST() {
-  return runSync();
-}
-
-export async function GET() {
+export async function POST(req: Request) {
+  const gate = requireSession(req);
+  if (gate) return gate;
   return runSync();
 }

--- a/app/api/webhooks/manychat/route.ts
+++ b/app/api/webhooks/manychat/route.ts
@@ -1,8 +1,18 @@
 import { NextResponse } from 'next/server';
+import { timingSafeEqual } from 'node:crypto';
 import { getDb } from '@/lib/data';
 import { parseManyChatWebhook } from '@/lib/connectors/manychat-webhook';
 
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs'; // node:crypto + better-sqlite3
+
+/** Constant-time string compare (guards against timing oracles on the secret). */
+function secretsMatch(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
 
 /**
  * ManyChat "External Request" ingest. ManyChat's API can't be polled for DMs,
@@ -11,12 +21,17 @@ export const dynamic = 'force-dynamic';
  * carrying the contact + message. Each message upserts by id, so replays don't
  * duplicate.
  *
- * If MANYCHAT_WEBHOOK_SECRET is set, the request must carry a matching
- * `x-manychat-secret` header (add it in the ManyChat External Request headers).
+ * MANYCHAT_WEBHOOK_SECRET is REQUIRED: without it the endpoint is disabled
+ * (503) rather than accepting unsigned POSTs. Every request must carry a
+ * matching `x-manychat-secret` header (add it in the ManyChat External Request
+ * headers), compared in constant time.
  */
 export async function POST(request: Request): Promise<Response> {
-  const secret = process.env.MANYCHAT_WEBHOOK_SECRET;
-  if (secret && request.headers.get('x-manychat-secret') !== secret) {
+  const secret = process.env.MANYCHAT_WEBHOOK_SECRET?.trim();
+  if (!secret) {
+    return NextResponse.json({ error: 'webhook secret not configured' }, { status: 503 });
+  }
+  if (!secretsMatch(request.headers.get('x-manychat-secret') ?? '', secret)) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 
@@ -30,13 +45,13 @@ export async function POST(request: Request): Promise<Response> {
   return NextResponse.json({ ok: true, id: message.id, subscriberId: message.subscriberId });
 }
 
-/** Lightweight health check: how many DMs are stored. */
+/** Lightweight health check. Reports only whether the endpoint is secured —
+ *  never the stored message count (that leaked inbox volume to any caller). */
 export async function GET(): Promise<Response> {
-  const secret = process.env.MANYCHAT_WEBHOOK_SECRET;
+  const secret = process.env.MANYCHAT_WEBHOOK_SECRET?.trim();
   return NextResponse.json({
     ok: true,
     endpoint: 'manychat-webhook',
     secured: Boolean(secret),
-    stored: getDb().social.dmMessages('instagram').length,
   });
 }

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,13 @@
+/**
+ * Runs once at server startup (Next `instrumentation` hook). Enforces the
+ * production access-gate invariant: a public deployment must never boot without
+ * FOUNDER_OS_ACCESS_TOKEN set. See lib/access-gate.ts.
+ */
+export async function register() {
+  // Only the Node.js runtime needs (and can run) the boot check; skip the edge
+  // bundle so it stays minimal.
+  if (process.env.NEXT_RUNTIME === 'nodejs' || !process.env.NEXT_RUNTIME) {
+    const { assertProductionAccessToken } = await import('@/lib/access-gate');
+    assertProductionAccessToken();
+  }
+}

--- a/lib/access-gate.ts
+++ b/lib/access-gate.ts
@@ -4,14 +4,17 @@
  * Deployed FounderOS instances live on public URLs (Railway hands out
  * *.up.railway.app). Set FOUNDER_OS_ACCESS_TOKEN and every request must
  * present the token once (?token=… or the challenge form); a cookie remembers
- * the browser after that. Leave it unset and the gate stays open — local dev
- * and the read-only demo deployment are unaffected.
+ * the browser after that. Leave it unset OUTSIDE production and the gate stays
+ * open — local dev and the read-only demo deployment are unaffected. In
+ * production an unset token fails closed (challenge), and the server refuses to
+ * boot at all (assertProductionAccessToken) so a public deployment can never
+ * come up wide open.
  */
 
 export const GATE_COOKIE = 'founder_os_access';
 
 export type GateDecision =
-  | { kind: 'open' } // no token configured — gate disabled
+  | { kind: 'open' } // no token configured, non-production — gate disabled
   | { kind: 'pass' } // cookie already carries the token
   | { kind: 'set-cookie'; value: string } // correct ?token= — set cookie, clean the URL
   | { kind: 'challenge' }; // everything else — show the token form
@@ -20,13 +23,33 @@ export function gateDecision(input: {
   token: string | undefined;
   cookie: string | null;
   queryToken: string | null;
+  isProduction?: boolean;
 }): GateDecision {
   const token = input.token?.trim();
-  if (!token) return { kind: 'open' };
+  if (!token) {
+    // Fail CLOSED in production: an unset token must never leave a public
+    // deployment open. Outside production the gate is disabled as before.
+    return input.isProduction ? { kind: 'challenge' } : { kind: 'open' };
+  }
   // fresh correct query token wins even over a stale cookie
   if (input.queryToken === token) return { kind: 'set-cookie', value: token };
   if (input.cookie === token) return { kind: 'pass' };
   return { kind: 'challenge' };
+}
+
+/**
+ * Refuse to boot a production server without an access token. Called once at
+ * startup from instrumentation.ts. In production an unset token can only ever
+ * serve the challenge page (fail closed) — an unusable, misconfigured state —
+ * so we stop the process rather than ship a locked-out (or, on any regression,
+ * wide-open) OS.
+ */
+export function assertProductionAccessToken(env: NodeJS.ProcessEnv = process.env): void {
+  if (env.NODE_ENV === 'production' && !env.FOUNDER_OS_ACCESS_TOKEN?.trim()) {
+    throw new Error(
+      'FOUNDER_OS_ACCESS_TOKEN must be set in production — refusing to boot without the access gate.',
+    );
+  }
 }
 
 /** Self-contained challenge page: no app chrome, no data, just the form. */

--- a/lib/agents/chat.ts
+++ b/lib/agents/chat.ts
@@ -14,6 +14,9 @@ import type { AgentMessage } from '@/lib/schemas';
 export type ChatResult = { reply: string; messages: AgentMessage[] };
 
 const SCREEN_CONTEXT_CAP = 4000;
+// Cap how many prior turns are sent to the model per request. Unbounded history
+// grows the token bill (and latency) without limit on a long-lived agent thread.
+const HISTORY_TURN_CAP = Number(process.env.AGENT_CHAT_HISTORY_CAP ?? 20);
 
 export function systemPromptFor(agent: RuntimeAgent, screenContext?: string): string {
   const lines = [
@@ -49,7 +52,7 @@ export async function chatWithAgent(
   // (a bare {role:'tool'} string isn't a valid v6 tool-result part) — so on
   // follow-up turns the model sees the assistant's prose, not raw tool output.
   // Fine for v1 read-only chat; revisit if multi-turn tool reasoning is needed.
-  const history = db.agentMessages.byAgent(agentId);
+  const history = db.agentMessages.byAgent(agentId).slice(-HISTORY_TURN_CAP);
   const llmMessages: LlmMessage[] = history.map((m) => ({ role: m.role, content: m.content }));
   const tools = agent.chatTools?.();
 

--- a/lib/connectors/arcads.ts
+++ b/lib/connectors/arcads.ts
@@ -1,8 +1,8 @@
-import { CRED_FILES, resolveCred } from '@/lib/creds';
+import { resolveCred } from '@/lib/creds';
 import type { ConnectorStatus } from '@/lib/connectors/types';
 
 export async function arcadsStatus(): Promise<ConnectorStatus> {
-  const auth = resolveCred('ARCADS_BASIC_AUTH', [CRED_FILES.arcads]);
+  const auth = resolveCred('ARCADS_BASIC_AUTH');
   if (!auth) {
     return {
       id: 'arcads',

--- a/lib/connectors/attio.ts
+++ b/lib/connectors/attio.ts
@@ -10,7 +10,7 @@ export async function attioStatus(): Promise<ConnectorStatus> {
       name: 'Attio (CRM)',
       kind: 'crm',
       state: 'not_configured',
-      detail: 'ATTIO_API_KEY not found in env or ~/.config/mcp.json mcpServers.',
+      detail: 'ATTIO_API_KEY not set (add it to .env.local).',
     };
   }
   try {

--- a/lib/connectors/ghl.ts
+++ b/lib/connectors/ghl.ts
@@ -4,13 +4,13 @@
  * a Private Integration Token (Settings → Private Integrations, read scopes)
  * plus the location id. Never reports a fake "connected".
  */
-import { resolveCred, CRED_FILES } from '@/lib/creds';
+import { resolveCred } from '@/lib/creds';
 import type { ConnectorStatus } from '@/lib/connectors/types';
 
 export async function ghlStatus(): Promise<ConnectorStatus> {
   const base = { id: 'ghl', name: 'GoHighLevel', kind: 'crm' } as const;
-  const key = resolveCred('GHL_API_KEY', [CRED_FILES.agentsEnv]);
-  const locationId = resolveCred('GHL_LOCATION_ID', [CRED_FILES.agentsEnv]);
+  const key = resolveCred('GHL_API_KEY');
+  const locationId = resolveCred('GHL_LOCATION_ID');
   if (!key || !locationId) {
     return {
       ...base,

--- a/lib/connectors/index.ts
+++ b/lib/connectors/index.ts
@@ -19,7 +19,7 @@ import { trakyoStatus } from '@/lib/connectors/trakyo';
 import { metaAdsStatus } from '@/lib/connectors/meta-ads';
 import { ghlStatus } from '@/lib/connectors/ghl';
 import { getBrainProvider } from '@/lib/brain';
-import { resolveManychatKey, runtimeEnv } from '@/lib/creds';
+import { runtimeEnv } from '@/lib/creds';
 import type { ConnectorStatus } from '@/lib/connectors/types';
 
 async function brainConnectorStatus(): Promise<ConnectorStatus> {
@@ -40,17 +40,7 @@ const CHECKS: [string, ConnectorStatus['kind'], () => Promise<ConnectorStatus>][
   ['whatsapp', 'social', whatsappStatus],
   ['zernio', 'social', zernioStatus],
   ['beehiiv', 'social', () => beehiivStatus(runtimeEnv())],
-  [
-    'manychat',
-    'social',
-    () => {
-      // Alex's real key rides in ~/.config/mcp.json (the manychat MCP
-      // registration), same reuse pattern as Attio — .env.local still wins.
-      const env = runtimeEnv();
-      if (!env.MANYCHAT_API_KEY) env.MANYCHAT_API_KEY = resolveManychatKey();
-      return manychatStatus(env);
-    },
-  ],
+  ['manychat', 'social', () => manychatStatus(runtimeEnv())],
   ['attio', 'crm', attioStatus],
   ['webinarjam', 'crm', webinarjamStatus],
   ['trakyo', 'crm', trakyoStatus],

--- a/lib/connectors/llm.ts
+++ b/lib/connectors/llm.ts
@@ -8,7 +8,7 @@
  * AI_GATEWAY_API_KEY ⇒ not_configured, never a fake "connected".
  */
 import { z } from 'zod';
-import { CRED_FILES, resolveCred } from '@/lib/creds';
+import { resolveCred } from '@/lib/creds';
 import type { ConnectorStatus } from '@/lib/connectors/types';
 
 export type LlmRole = 'system' | 'user' | 'assistant' | 'tool';
@@ -40,9 +40,9 @@ export interface LlmProvider {
 const GATEWAY_KEY = 'AI_GATEWAY_API_KEY';
 const DEFAULT_MODEL = process.env.LLM_MODEL ?? 'anthropic/claude-sonnet-5';
 
-/** process.env first (Next auto-loads .env.local), then Alex's cred files. */
+/** .env.local (fresh) then process.env — no machine-wide file fallback. */
 function resolveGatewayKey(): string | undefined {
-  return resolveCred(GATEWAY_KEY, [CRED_FILES.agentsEnv, CRED_FILES.socialMedia]);
+  return resolveCred(GATEWAY_KEY);
 }
 
 /** Stub trigger: a user message containing `use-tool:<name>` fires that tool. */
@@ -72,8 +72,8 @@ export function createGatewayProvider(model: string = DEFAULT_MODEL): LlmProvide
     name: 'gateway',
     async chat(req) {
       // Fail fast with an honest message instead of letting the SDK hang —
-      // and hydrate process.env from Alex's cred files so a key that
-      // exists outside .env.local still works.
+      // and hydrate process.env from a fresh .env.local read so a key pasted
+      // via the connect flow works without a restart.
       const key = resolveGatewayKey();
       if (!key) {
         throw new Error('AI_GATEWAY_API_KEY is not set — add it to .env.local to enable agent chat.');

--- a/lib/connectors/meta-ads.ts
+++ b/lib/connectors/meta-ads.ts
@@ -4,14 +4,14 @@
  * arrives via the Meta Ads MCP; until a token shows up this is a status-only
  * connector, same pattern as trakyo.ts. Never reports a fake "connected".
  */
-import { resolveCred, CRED_FILES } from '@/lib/creds';
+import { resolveCred } from '@/lib/creds';
 import type { ConnectorStatus } from '@/lib/connectors/types';
 
 const KEY = 'META_ADS_ACCESS_TOKEN';
 
 export async function metaAdsStatus(): Promise<ConnectorStatus> {
   const base = { id: 'meta-ads', name: 'Meta Ads', kind: 'ads' } as const;
-  const key = resolveCred(KEY, [CRED_FILES.agentsEnv, CRED_FILES.socialMedia]);
+  const key = resolveCred(KEY);
   if (!key) {
     return {
       ...base,

--- a/lib/connectors/miro.ts
+++ b/lib/connectors/miro.ts
@@ -1,15 +1,15 @@
-import { CRED_FILES, resolveCred } from '@/lib/creds';
+import { resolveCred } from '@/lib/creds';
 import type { ConnectorStatus } from '@/lib/connectors/types';
 
 export async function miroStatus(): Promise<ConnectorStatus> {
-  const token = resolveCred('MIRO_ACCESS_TOKEN', [CRED_FILES.agentsEnv]);
+  const token = resolveCred('MIRO_ACCESS_TOKEN');
   if (!token) {
     return {
       id: 'miro',
       name: 'Miro',
       kind: 'creative',
       state: 'not_configured',
-      detail: 'MIRO_ACCESS_TOKEN not found in env or knowledge/.env.agents.',
+      detail: 'MIRO_ACCESS_TOKEN not set (add it to .env.local).',
     };
   }
   try {

--- a/lib/connectors/trakyo.ts
+++ b/lib/connectors/trakyo.ts
@@ -6,14 +6,14 @@
  * TRAKYO_API_KEY is set (live request shape lands when the API is published).
  * Never reports a fake "connected".
  */
-import { resolveCred, CRED_FILES } from '@/lib/creds';
+import { resolveCred } from '@/lib/creds';
 import type { ConnectorStatus } from '@/lib/connectors/types';
 
 const KEY = 'TRAKYO_API_KEY';
 
 export async function trakyoStatus(): Promise<ConnectorStatus> {
   const base = { id: 'trakyo', name: 'Trakyo', kind: 'crm' } as const;
-  const key = resolveCred(KEY, [CRED_FILES.agentsEnv, CRED_FILES.socialMedia]);
+  const key = resolveCred(KEY);
   if (!key) {
     return {
       ...base,

--- a/lib/connectors/webinarjam.ts
+++ b/lib/connectors/webinarjam.ts
@@ -9,7 +9,7 @@
  *   POST /webinarjam/webinars     { api_key }                       → validate
  *   POST /webinarjam/registrants  { api_key, webinar_id, schedule_id } → leads
  */
-import { resolveCred, CRED_FILES } from '@/lib/creds';
+import { resolveCred } from '@/lib/creds';
 import type { ConnectorStatus } from '@/lib/connectors/types';
 
 const KEY = 'WEBINARJAM_API_KEY';
@@ -18,7 +18,7 @@ const BASE = 'https://api.webinarjam.com/webinarjam';
 type Fetch = typeof fetch;
 
 function resolveKey(): string | undefined {
-  return resolveCred(KEY, [CRED_FILES.agentsEnv, CRED_FILES.socialMedia]);
+  return resolveCred(KEY);
 }
 
 function form(params: Record<string, string>): URLSearchParams {

--- a/lib/connectors/zernio.ts
+++ b/lib/connectors/zernio.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { CRED_FILES, resolveCred } from '@/lib/creds';
+import { resolveCred } from '@/lib/creds';
 import type { ConnectorStatus } from '@/lib/connectors/types';
 
 const CONFIG_PATH = path.join(os.homedir(), '.config/social', 'config.json');
@@ -26,7 +26,7 @@ export function zernioAccounts(): Record<string, { handle?: string; followers?: 
 }
 
 export function zernioKey(): string | undefined {
-  return resolveCred('ZERNIO_API_KEY', [CRED_FILES.socialMedia, CRED_FILES.agentsEnv]);
+  return resolveCred('ZERNIO_API_KEY');
 }
 
 // ── Live follower counts ────────────────────────────────────────────────────
@@ -220,7 +220,7 @@ export async function zernioStatus(): Promise<ConnectorStatus> {
       name: 'Zernio (Social)',
       kind: 'social',
       state: 'not_configured',
-      detail: 'ZERNIO_API_KEY not found in env, ~/.config/social/.env, or knowledge/.env.agents.',
+      detail: 'ZERNIO_API_KEY not set (add it to .env.local).',
     };
   }
   const followers = accounts.reduce((sum, [, a]) => sum + (a.followers ?? 0), 0);

--- a/lib/creds.ts
+++ b/lib/creds.ts
@@ -1,13 +1,13 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
 /**
- * Credential resolution for connectors. Alex's keys already live in
- * canonical locations around the machine (~/.config/social/.env,
- * knowledge/.env.agents, ~/.config/mcp.json, project .env files). Connectors
- * resolve from process.env first, then fall back to those files at runtime —
- * no secrets are ever copied into this repo.
+ * Credential resolution for connectors. Credentials come from the environment
+ * ONLY: process.env, plus the app's own gitignored `.env.local` (read fresh so
+ * the Connections board's connect flow takes effect without a restart). There
+ * is deliberately NO fallback to machine-wide files in the home directory —
+ * reading arbitrary ~/.config/* and ~/knowledge/* files let a compromised or
+ * misconfigured deploy pull in secrets that were never meant for this app.
  */
 
 export function parseEnvFile(content: string): Record<string, string> {
@@ -37,15 +37,6 @@ export function extractMcpEnvKey(claudeJson: unknown, server: string, key: strin
     ?.mcpServers;
   return servers?.[server]?.env?.[key];
 }
-
-const HOME = os.homedir();
-
-export const CRED_FILES = {
-  socialMedia: path.join(HOME, '.config/social', '.env'),
-  agentsEnv: path.join(HOME, 'knowledge', '.env.agents'),
-  arcads: path.join(HOME, 'Projects', 'arcads-agent-skills', '.env'),
-  claudeJson: path.join(HOME, '.config/mcp.json'),
-};
 
 function readEnvFileSafe(filePath: string): Record<string, string> {
   try {
@@ -117,38 +108,13 @@ export function runtimeEnv(): Record<string, string | undefined> {
   return { ...process.env, ...readEnvLocal() };
 }
 
-/** Fresh .env.local first, then process.env, then each env file in order. */
-export function resolveCred(name: string, files: string[]): string | undefined {
+/** Fresh .env.local first, then process.env. No machine-wide file fallback. */
+export function resolveCred(name: string): string | undefined {
   const fromLocal = readEnvLocal()[name];
   if (fromLocal) return fromLocal;
-  const fromEnv = process.env[name];
-  if (fromEnv) return fromEnv;
-  for (const file of files) {
-    const value = readEnvFileSafe(file)[name];
-    if (value) return value;
-  }
-  return undefined;
+  return process.env[name] || undefined;
 }
 
 export function resolveAttioKey(): string | undefined {
-  if (process.env.ATTIO_API_KEY) return process.env.ATTIO_API_KEY;
-  try {
-    const claudeJson = JSON.parse(fs.readFileSync(CRED_FILES.claudeJson, 'utf8'));
-    return extractMcpEnvKey(claudeJson, 'attio', 'ATTIO_API_KEY');
-  } catch {
-    return undefined;
-  }
-}
-
-/** ManyChat's key lives in ~/.config/mcp.json (the manychat MCP registration),
- *  same reuse pattern as Attio. .env.local / process.env still win. */
-export function resolveManychatKey(): string | undefined {
-  const direct = readEnvLocal().MANYCHAT_API_KEY ?? process.env.MANYCHAT_API_KEY;
-  if (direct) return direct;
-  try {
-    const claudeJson = JSON.parse(fs.readFileSync(CRED_FILES.claudeJson, 'utf8'));
-    return extractMcpEnvKey(claudeJson, 'manychat', 'MANYCHAT_API_KEY');
-  } catch {
-    return undefined;
-  }
+  return resolveCred('ATTIO_API_KEY');
 }

--- a/lib/funnel-ghl.ts
+++ b/lib/funnel-ghl.ts
@@ -10,7 +10,7 @@
  * first stage → first_touch, then engaged (<0.4), nurtured (<0.75), opted_in;
  * a `won` opportunity is the conversion regardless of stage.
  */
-import { resolveCred, CRED_FILES } from '@/lib/creds';
+import { resolveCred } from '@/lib/creds';
 import { FUNNEL_STAGES } from '@/lib/funnel';
 import { FunnelJourneySchema, type FunnelJourney, type FunnelStage, type FunnelTouch } from '@/lib/schemas';
 
@@ -156,8 +156,8 @@ export async function ghlFunnelJourneys(
   now = new Date(),
 ): Promise<{ journeys: FunnelJourney[]; excluded: number; total: number } | null> {
   if ((process.env.FUNNEL_PROVIDER ?? 'attio') !== 'attio') return null; // seed-pinned (tests)
-  const key = resolveCred('GHL_API_KEY', [CRED_FILES.agentsEnv]);
-  const locationId = resolveCred('GHL_LOCATION_ID', [CRED_FILES.agentsEnv]);
+  const key = resolveCred('GHL_API_KEY');
+  const locationId = resolveCred('GHL_LOCATION_ID');
   if (!key || !locationId) return null;
   const headers = { Authorization: `Bearer ${key}`, Version: GHL_VERSION, Accept: 'application/json' };
   try {

--- a/lib/funnel-trakyo.ts
+++ b/lib/funnel-trakyo.ts
@@ -5,7 +5,7 @@
  * plus a published endpoint exist; the merge logic below is real and tested,
  * so wiring the live pull is a one-function change on the day Trakyo ships.
  */
-import { resolveCred, CRED_FILES } from '@/lib/creds';
+import { resolveCred } from '@/lib/creds';
 import type { FunnelJourney } from '@/lib/schemas';
 
 /** One attributed content event as Trakyo will report it. */
@@ -46,7 +46,7 @@ export function mergeTrakyoTouches(journeys: FunnelJourney[], events: TrakyoEven
  * then the fetch lands here and every funnel first-touch lights up organic.
  */
 export async function trakyoTouches(): Promise<TrakyoEvent[]> {
-  const key = resolveCred('TRAKYO_API_KEY', [CRED_FILES.agentsEnv, CRED_FILES.socialMedia]);
+  const key = resolveCred('TRAKYO_API_KEY');
   if (!key) return [];
   return []; // endpoint TBD — Trakyo has no public API yet
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,44 @@
+/**
+ * In-memory fixed-window rate limiter. Sufficient for the single-replica deploy
+ * (numReplicas:1 in railway.json); if that ever scales out, swap the Map for a
+ * shared store (Redis/Upstash) behind the same interface.
+ *
+ * Each call increments the window's counter, so callers checking several limits
+ * (per-recipient, global, daily) fail slightly conservatively — which is the
+ * safe direction for an abuse control.
+ */
+export type RateVerdict = { ok: true } | { ok: false; retryAfter: number };
+
+type Window = { count: number; resetAt: number };
+const windows = new Map<string, Window>();
+
+export function rateLimit(
+  key: string,
+  limit: number,
+  windowMs: number,
+  now: number = Date.now(),
+): RateVerdict {
+  const w = windows.get(key);
+  if (!w || now >= w.resetAt) {
+    windows.set(key, { count: 1, resetAt: now + windowMs });
+    return { ok: true };
+  }
+  if (w.count >= limit) {
+    return { ok: false, retryAfter: Math.max(1, Math.ceil((w.resetAt - now) / 1000)) };
+  }
+  w.count += 1;
+  return { ok: true };
+}
+
+/** A 429 Response carrying Retry-After, for a failed verdict. */
+export function tooManyRequests(retryAfter: number): Response {
+  return new Response(JSON.stringify({ error: 'rate limit exceeded' }), {
+    status: 429,
+    headers: { 'content-type': 'application/json', 'retry-after': String(retryAfter) },
+  });
+}
+
+/** Test seam — clears all windows. */
+export function __resetRateLimits(): void {
+  windows.clear();
+}

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { GATE_COOKIE } from '@/lib/access-gate';
+
+/**
+ * Per-route authentication for mutating API handlers.
+ *
+ * The access gate (middleware.ts) already fronts the whole app, but middleware
+ * is a single perimeter: a misconfigured matcher, a rewrite, or a direct edge
+ * invocation can bypass it. Every mutating route therefore calls requireSession()
+ * first as defence in depth. The session is the same secret the gate issues —
+ * the FOUNDER_OS_ACCESS_TOKEN carried in the GATE_COOKIE — read straight off the
+ * incoming Request (works in the Next runtime AND in direct unit-test calls,
+ * unlike next/headers which needs a request scope).
+ */
+
+function gateCookie(req: Request): string | null {
+  const header = req.headers.get('cookie');
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    if (part.slice(0, eq).trim() === GATE_COOKIE) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
+  return null;
+}
+
+/**
+ * True when the caller holds a valid session. Mirrors the access gate:
+ * - token configured  → the gate cookie must match it.
+ * - no token          → open ONLY outside production. In production an unset
+ *   token means fail closed (and the process refuses to boot — see
+ *   assertProductionAccessToken in lib/access-gate.ts).
+ */
+export function hasSession(req: Request, env: NodeJS.ProcessEnv = process.env): boolean {
+  const token = env.FOUNDER_OS_ACCESS_TOKEN?.trim();
+  if (!token) return env.NODE_ENV !== 'production';
+  return gateCookie(req) === token;
+}
+
+/** Guard for mutating handlers: `const gate = requireSession(req); if (gate) return gate;` */
+export function requireSession(req: Request): Response | null {
+  if (hasSession(req)) return null;
+  return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,6 +11,7 @@ export function middleware(req: NextRequest) {
     token: process.env.FOUNDER_OS_ACCESS_TOKEN,
     cookie: req.cookies.get(GATE_COOKIE)?.value ?? null,
     queryToken: req.nextUrl.searchParams.get('token'),
+    isProduction: process.env.NODE_ENV === 'production',
   });
 
   switch (decision.kind) {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,30 @@ const nextConfig = {
   distDir: process.env.NEXT_DIST_DIR || '.next',
   experimental: {
     serverComponentsExternalPackages: ['better-sqlite3', 'node-ical', 'nodemailer'],
+    // Run instrumentation.ts at startup (Next 14 gates it behind this flag) so
+    // the production access-token boot check fires.
+    instrumentationHook: true,
+  },
+  // Baseline security headers on every response. Conservative set (no CSP, which
+  // needs per-request nonces here) — clickjacking, MIME-sniffing, referrer leak,
+  // transport downgrade, and powerful-feature access are all closed off.
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'X-DNS-Prefetch-Control', value: 'off' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+        ],
+      },
+    ];
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "lucide-react": "^0.441.0",
         "next": "^14.2.13",
         "node-ical": "^0.26.1",
-        "nodemailer": "^9.0.1",
+        "nodemailer": "^9.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "simple-icons": "^16.27.0",
@@ -2980,9 +2980,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
-      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.1.0.tgz",
+      "integrity": "sha512-xj1Ri5Sau3qpPffHJwi2bY0oWVVWYq62Ph17l+2v1xXpxjqTls3YPc3L8dub9mcJpxj+1ucNnuYVqLlgh4pmDA==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lucide-react": "^0.441.0",
     "next": "^14.2.13",
     "node-ical": "^0.26.1",
-    "nodemailer": "^9.0.1",
+    "nodemailer": "^9.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "simple-icons": "^16.27.0",

--- a/tests/access-gate.test.ts
+++ b/tests/access-gate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { gateDecision, challengePage, GATE_COOKIE } from '@/lib/access-gate';
+import { gateDecision, challengePage, GATE_COOKIE, assertProductionAccessToken } from '@/lib/access-gate';
 
 /**
  * The production access gate. A student's FounderOS deploys to a PUBLIC
@@ -14,6 +14,13 @@ describe('gateDecision', () => {
   test('no configured token → the gate is open (dev + demo unchanged)', () => {
     expect(gateDecision({ token: undefined, cookie: 'anything', queryToken: null }).kind).toBe('open');
     expect(gateDecision({ token: '', cookie: null, queryToken: null }).kind).toBe('open');
+  });
+
+  test('no configured token in PRODUCTION → fails closed (challenge, never open)', () => {
+    expect(gateDecision({ token: undefined, cookie: 'anything', queryToken: null, isProduction: true }).kind).toBe(
+      'challenge',
+    );
+    expect(gateDecision({ token: '', cookie: null, queryToken: null, isProduction: true }).kind).toBe('challenge');
   });
 
   test('matching cookie passes silently', () => {
@@ -34,6 +41,25 @@ describe('gateDecision', () => {
   test('a stale cookie loses to a fresh correct query token', () => {
     const d = gateDecision({ token: 'new-token', cookie: 'old-token', queryToken: 'new-token' });
     expect(d.kind).toBe('set-cookie');
+  });
+});
+
+describe('assertProductionAccessToken', () => {
+  test('throws in production when the token is missing or blank', () => {
+    expect(() => assertProductionAccessToken({ NODE_ENV: 'production' } as NodeJS.ProcessEnv)).toThrow(
+      /FOUNDER_OS_ACCESS_TOKEN/,
+    );
+    expect(() =>
+      assertProductionAccessToken({ NODE_ENV: 'production', FOUNDER_OS_ACCESS_TOKEN: '   ' } as NodeJS.ProcessEnv),
+    ).toThrow();
+  });
+
+  test('is a no-op in production with a token, and always outside production', () => {
+    expect(() =>
+      assertProductionAccessToken({ NODE_ENV: 'production', FOUNDER_OS_ACCESS_TOKEN: 'sekrit' } as NodeJS.ProcessEnv),
+    ).not.toThrow();
+    expect(() => assertProductionAccessToken({ NODE_ENV: 'development' } as NodeJS.ProcessEnv)).not.toThrow();
+    expect(() => assertProductionAccessToken({ NODE_ENV: 'test' } as NodeJS.ProcessEnv)).not.toThrow();
   });
 });
 

--- a/tests/creds.test.ts
+++ b/tests/creds.test.ts
@@ -94,9 +94,9 @@ describe('env.local as a live credential store (connect flow)', () => {
   test('resolveCred prefers a fresh env.local read over a stale process.env', () => {
     process.env.STALE_TEST_KEY = 'from-boot';
     upsertEnvLocal({ STALE_TEST_KEY: 'from-file' });
-    expect(resolveCred('STALE_TEST_KEY', [])).toBe('from-file');
+    expect(resolveCred('STALE_TEST_KEY')).toBe('from-file');
     delete process.env.STALE_TEST_KEY;
-    expect(resolveCred('STALE_TEST_KEY', [])).toBe('from-file');
+    expect(resolveCred('STALE_TEST_KEY')).toBe('from-file');
   });
 
   test('runtimeEnv overlays env.local onto process.env', () => {

--- a/tests/manychat-webhook-route.test.ts
+++ b/tests/manychat-webhook-route.test.ts
@@ -3,11 +3,12 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-// Own temp DB so ingest is observable in isolation. Secret read at request
-// time, so tests can toggle MANYCHAT_WEBHOOK_SECRET between calls.
+// Own temp DB so ingest is observable in isolation. The shared secret is now
+// REQUIRED, so it's set for the whole suite; individual tests toggle it to
+// exercise the disabled (503) and unauthorized (401) paths.
 beforeAll(() => {
   process.env.FOUNDER_OS_DB = path.join(mkdtempSync(path.join(tmpdir(), 'alex-mc-wh-')), 'test.db');
-  delete process.env.MANYCHAT_WEBHOOK_SECRET;
+  process.env.MANYCHAT_WEBHOOK_SECRET = 's3cret';
 });
 
 const URL = 'http://localhost/api/webhooks/manychat';
@@ -18,7 +19,10 @@ describe('POST /api/webhooks/manychat', () => {
   test('ingests a DM and it lands in the inbox as source=manychat', async () => {
     const { POST } = await import('@/app/api/webhooks/manychat/route');
     const res = await POST(
-      post({ subscriber_id: 'wh-1', name: 'Webhook Wendy', handle: 'wendy', text: 'came from manychat', ts: '2026-07-18T16:00:00.000Z' }),
+      post(
+        { subscriber_id: 'wh-1', name: 'Webhook Wendy', handle: 'wendy', text: 'came from manychat', ts: '2026-07-18T16:00:00.000Z' },
+        { 'x-manychat-secret': 's3cret' },
+      ),
     );
     expect(res.status).toBe(200);
     expect((await res.json()).ok).toBe(true);
@@ -29,14 +33,21 @@ describe('POST /api/webhooks/manychat', () => {
     expect(found?.source).toBe('manychat');
   });
 
-  test('rejects an unparseable payload with 400', async () => {
+  test('rejects an unparseable payload with 400 (once authenticated)', async () => {
     const { POST } = await import('@/app/api/webhooks/manychat/route');
-    const res = await POST(post({ text: 'no subscriber id' }));
+    const res = await POST(post({ text: 'no subscriber id' }, { 'x-manychat-secret': 's3cret' }));
     expect(res.status).toBe(400);
   });
 
-  test('enforces the shared secret when MANYCHAT_WEBHOOK_SECRET is set', async () => {
+  test('is disabled with 503 when no secret is configured', async () => {
+    delete process.env.MANYCHAT_WEBHOOK_SECRET;
+    const { POST } = await import('@/app/api/webhooks/manychat/route');
+    const res = await POST(post({ subscriber_id: 'x', text: 'hi' }));
+    expect(res.status).toBe(503);
     process.env.MANYCHAT_WEBHOOK_SECRET = 's3cret';
+  });
+
+  test('enforces the shared secret: 401 without it, 200 with it', async () => {
     const { POST } = await import('@/app/api/webhooks/manychat/route');
 
     const bad = await POST(post({ subscriber_id: 'x', text: 'hi' }));
@@ -44,7 +55,5 @@ describe('POST /api/webhooks/manychat', () => {
 
     const good = await POST(post({ subscriber_id: 'x', text: 'hi' }, { 'x-manychat-secret': 's3cret' }));
     expect(good.status).toBe(200);
-
-    delete process.env.MANYCHAT_WEBHOOK_SECRET;
   });
 });

--- a/tests/route-auth.test.ts
+++ b/tests/route-auth.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Every mutating API handler (POST/PUT/PATCH/DELETE) must authenticate before
+ * doing work. This net fails the build if a new mutating route ships without a
+ * requireSession() guard — the failure mode that left the whole API open.
+ *
+ * The ManyChat webhook is the one exception: it is a machine-to-machine push
+ * that cannot carry the operator's session cookie, so it authenticates with the
+ * required MANYCHAT_WEBHOOK_SECRET (see its route + test) instead.
+ */
+const SECRET_AUTHENTICATED = new Set(['webhooks/manychat']);
+const MUTATING = /export\s+(async\s+)?function\s+(POST|PUT|PATCH|DELETE)\b/;
+
+function routeFiles(dir: string, base = ''): { route: string; file: string }[] {
+  const out: { route: string; file: string }[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const rel = base ? `${base}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) out.push(...routeFiles(path.join(dir, entry.name), rel));
+    else if (entry.name === 'route.ts') out.push({ route: rel.replace(/\/route\.ts$/, ''), file: path.join(dir, entry.name) });
+  }
+  return out;
+}
+
+const apiDir = path.join(process.cwd(), 'app', 'api');
+const mutatingRoutes = routeFiles(apiDir)
+  .map((r) => ({ ...r, src: readFileSync(r.file, 'utf8') }))
+  .filter((r) => MUTATING.test(r.src));
+
+describe('every mutating API route authenticates', () => {
+  test('there are mutating routes to check (net is live)', () => {
+    expect(mutatingRoutes.length).toBeGreaterThan(10);
+  });
+
+  test.each(mutatingRoutes.filter((r) => !SECRET_AUTHENTICATED.has(r.route)))(
+    '$route calls requireSession',
+    ({ src }) => {
+      expect(src).toContain("from '@/lib/session'");
+      expect(src).toMatch(/requireSession\(/);
+    },
+  );
+
+  test.each(mutatingRoutes.filter((r) => SECRET_AUTHENTICATED.has(r.route)))(
+    '$route (webhook) authenticates via the required shared secret',
+    ({ src }) => {
+      expect(src).toContain('MANYCHAT_WEBHOOK_SECRET');
+      expect(src).toContain('timingSafeEqual');
+    },
+  );
+});

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { hasSession, requireSession } from '@/lib/session';
+import { GATE_COOKIE } from '@/lib/access-gate';
+
+const req = (cookie?: string) =>
+  new Request('http://localhost/api/x', cookie ? { headers: { cookie } } : undefined);
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('hasSession', () => {
+  test('no token, outside production → open', () => {
+    expect(hasSession(req(), { NODE_ENV: 'development' } as NodeJS.ProcessEnv)).toBe(true);
+    expect(hasSession(req(), { NODE_ENV: 'test' } as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  test('no token in production → closed (fail closed)', () => {
+    expect(hasSession(req(), { NODE_ENV: 'production' } as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  test('token configured → the gate cookie must match', () => {
+    const env = { NODE_ENV: 'production', FOUNDER_OS_ACCESS_TOKEN: 'sekrit' } as NodeJS.ProcessEnv;
+    expect(hasSession(req(), env)).toBe(false);
+    expect(hasSession(req(`${GATE_COOKIE}=wrong`), env)).toBe(false);
+    expect(hasSession(req(`${GATE_COOKIE}=sekrit`), env)).toBe(true);
+    // survives other cookies present alongside it
+    expect(hasSession(req(`foo=bar; ${GATE_COOKIE}=sekrit; baz=1`), env)).toBe(true);
+  });
+});
+
+describe('requireSession', () => {
+  test('returns a 401 Response when there is no session', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('FOUNDER_OS_ACCESS_TOKEN', '');
+    const res = requireSession(req());
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+    expect((await res!.json()).error).toBe('unauthorized');
+  });
+
+  test('returns null (proceed) when the session is valid', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('FOUNDER_OS_ACCESS_TOKEN', 'sekrit');
+    expect(requireSession(req(`${GATE_COOKIE}=sekrit`))).toBeNull();
+  });
+
+  test('returns null in dev when no token is configured', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('FOUNDER_OS_ACCESS_TOKEN', '');
+    expect(requireSession(req())).toBeNull();
+  });
+});

--- a/tests/smoke-api.test.ts
+++ b/tests/smoke-api.test.ts
@@ -46,7 +46,7 @@ const ROUTES: RouteEntry[] = [
   { route: 'social/history', load: () => import('@/app/api/social/history/route'), url: 'http://localhost/api/social/history?limit=6' },
   { route: 'social/posts', load: () => import('@/app/api/social/posts/route'), url: 'http://localhost/api/social/posts' },
   { route: 'social/series', load: () => import('@/app/api/social/series/route'), url: 'http://localhost/api/social/series?metric=audience' },
-  { route: 'social/sync', load: () => import('@/app/api/social/sync/route'), url: 'http://localhost/api/social/sync' },
+  // social/sync is POST-only (its state-mutating GET was removed for CSRF safety).
   { route: 'tools', load: () => import('@/app/api/tools/route'), url: 'http://localhost/api/tools' },
   { route: 'ventures', load: () => import('@/app/api/ventures/route'), url: 'http://localhost/api/ventures' },
   { route: 'webhooks/manychat', load: () => import('@/app/api/webhooks/manychat/route'), url: 'http://localhost/api/webhooks/manychat' },


### PR DESCRIPTION
CRITICAL
- access gate fails closed in production and refuses to boot without FOUNDER_OS_ACCESS_TOKEN (lib/access-gate.ts, middleware.ts, instrumentation.ts)
- comms/reply: require session + per-recipient/global/daily send caps

HIGH
- shared requireSession() guard on every mutating route + enumeration test
- keys POST gated behind session
- creds: drop home-directory credential fallback, process.env/.env.local only
- agents/[id]/chat: session + rate + daily cost cap + capped history
- manychat webhook: required secret (503 if unset), timingSafeEqual, drop stored

Also: nodemailer ^9.1.0, remove state-mutating social/sync GET, generic client errors, PDF size cap + content-sniff, security headers in next.config.mjs