### PR TITLE
chore: bump better-sqlite3 to v12 for Node 24 prebuilt binaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@slack/web-api": "^7.16.0",
         "@types/d3-force": "^3.0.10",
         "ai": "^6.0.208",
-        "better-sqlite3": "^11.3.0",
+        "better-sqlite3": "^12.11.1",
         "d3-force": "^3.0.0",
         "imapflow": "^1.4.0",
         "lucide-react": "^0.441.0",
@@ -1597,14 +1597,17 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/binary-extensions": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@slack/web-api": "^7.16.0",
     "@types/d3-force": "^3.0.10",
     "ai": "^6.0.208",
-    "better-sqlite3": "^11.3.0",
+    "better-sqlite3": "^12.11.1",
     "d3-force": "^3.0.0",
     "imapflow": "^1.4.0",
     "lucide-react": "^0.441.0",


### PR DESCRIPTION
## What changed

Bumps `better-sqlite3` from `^11.3.0` to `^12.11.1` in `package.json` (+ lockfile).

## Why

`better-sqlite3@11` publishes no prebuilt binaries for Node 24. On a machine running Node 24, `npm install` falls back to a `node-gyp` source build, which fails unless the Visual Studio "Desktop development with C++" toolchain is installed:

```
prebuild-install warn install No prebuilt binaries found (target=24.14.0 runtime=node arch=x64 platform=win32)
gyp ERR! find VS Could not find any Visual Studio installation to use
```

v12 ships Node 24 prebuilds, so `npm install` works out of the box. The v12 major only drops support for Node < 20; the API surface used here is unchanged.

## Verification

- `npm install` succeeds on Windows 10 / Node 24.14.0 with no build tools
- Native module loads: SQLite 3.53.2
- `npm run typecheck` clean
- `npm test`: 961 / 963 pass. The 2 failures are environmental and reproduce independently of this change — a 5s Vitest timeout on first cold run, and a Windows file-lock in an `fs.rmSync` teardown.

## Reviewer notes

- README says Node 18+; this bump implies Node 20+ in practice. Worth a README touch if you want to keep that line accurate — left out of this PR to keep it a one-line dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
